### PR TITLE
Accessibility Support :

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -37,6 +37,8 @@ const ButtonGroup = props => {
     setOpacityTo,
     containerBorderRadius,
     disableSelected,
+    accessibilityLabelSelectedSuffix,
+    accessibilityLabelUnSelectedSuffix,
     ...attributes
   } = rest;
 
@@ -122,6 +124,7 @@ const ButtonGroup = props => {
                 ) : (
                   <Text
                     testID="buttonGroupItemText"
+                    accessibilityLabel={`${button} ${selectedIndex === i?!!accessibilityLabelSelectedSuffix?accessibilityLabelSelectedSuffix:'':!!accessibilityLabelUnSelectedSuffix?accessibilityLabelUnSelectedSuffix:''}`}
                     style={StyleSheet.flatten([
                       styles.buttonText(theme),
                       textStyle && textStyle,


### PR DESCRIPTION
added 'accessibilityLabelSelectedSuffix', 'accessibilityLabelUnSelectedSuffix'  as a props. It will allow to added customised accessibilityLabel for ADA support.  

e.g. I have a Button Groups of two tabs 'Tab1', 'Tab2', and Tab1 is selected 
it will speak for Tab1 ==> Tab1  selected (Will add Suffix for selected tab)
It will speak for Tab2 ==> Tab2 double tap to activate (Will add Suffix for unselected tab)

```
                                        <ButtonGroup
						accessibilityLabelSelectedSuffix={'button selected'}
						accessibilityLabelUnSelectedSuffix={'button double tap to activate'}
						buttons={buttons}
					/>
```