### PR TITLE
[Icon] Add reverseRatio prop

### DIFF
--- a/docs/icon.md
+++ b/docs/icon.md
@@ -91,6 +91,7 @@ import { Icon } from 'react-native-elements'
 - [`onLongPress`](#onlongpress)
 - [`raised`](#raised)
 - [`reverse`](#reverse)
+- [`reverseRatio`](#reverseratio)
 - [`reverseColor`](#reversecolor)
 - [`size`](#size)
 - [`type`](#type)
@@ -240,6 +241,14 @@ add styling to container holding icon (optional)
 | object (style) | inherited styling |
 
 ---
+
+### `reverseRatio`
+
+specify reverse icon ratio (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   1.5   |
 
 ### `reverseColor`
 

--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -48,9 +48,9 @@ const Icon = props => {
         style={StyleSheet.flatten([
           (reverse || raised) && styles.button,
           (reverse || raised) && {
-            borderRadius: (size * reverseRatio) / 2,
-            height: size * reverseRatio,
-            width: size * reverseRatio,
+            borderRadius: (size * reverseRatio + 4) / 2,
+            height: size * reverseRatio + 4,
+            width: size * reverseRatio + 4,
           },
           raised && styles.raised,
           {
@@ -103,7 +103,7 @@ Icon.defaultProps = {
   raised: false,
   size: 24,
   color: 'black',
-  reverseRatio: 1.5,
+  reverseRatio: 2,
   reverseColor: 'white',
   disabled: false,
   type: 'material',

--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -22,6 +22,7 @@ const Icon = props => {
     reverse,
     raised,
     containerStyle,
+    reverseRatio,
     reverseColor,
     disabled,
     disabledStyle,
@@ -47,9 +48,9 @@ const Icon = props => {
         style={StyleSheet.flatten([
           (reverse || raised) && styles.button,
           (reverse || raised) && {
-            borderRadius: size + 4,
-            height: size * 2 + 4,
-            width: size * 2 + 4,
+            borderRadius: (size * reverseRatio) / 2,
+            height: size * reverseRatio,
+            width: size * reverseRatio,
           },
           raised && styles.raised,
           {
@@ -90,6 +91,7 @@ Icon.propTypes = {
   containerStyle: ViewPropTypes.style,
   iconStyle: NativeText.propTypes.style,
   onPress: PropTypes.func,
+  reverseRatio: PropTypes.number,
   reverseColor: PropTypes.string,
   disabled: PropTypes.bool,
   disabledStyle: ViewPropTypes.style,
@@ -101,6 +103,7 @@ Icon.defaultProps = {
   raised: false,
   size: 24,
   color: 'black',
+  reverseRatio: 1.5,
   reverseColor: 'white',
   disabled: false,
   type: 'material',

--- a/src/icons/__tests__/__snapshots__/Icon.js.snap
+++ b/src/icons/__tests__/__snapshots__/Icon.js.snap
@@ -105,7 +105,7 @@ exports[`Icon component should apply raised styles 1`] = `
       Object {
         "alignItems": "center",
         "backgroundColor": "white",
-        "borderRadius": 28,
+        "borderRadius": 26,
         "height": 52,
         "justifyContent": "center",
         "margin": 7,
@@ -144,7 +144,7 @@ exports[`Icon component should apply reverse styles 1`] = `
       Object {
         "alignItems": "center",
         "backgroundColor": "black",
-        "borderRadius": 28,
+        "borderRadius": 26,
         "height": 52,
         "justifyContent": "center",
         "margin": 7,
@@ -258,7 +258,7 @@ exports[`Icon component should render with icon type 1`] = `
       Object {
         "alignItems": "center",
         "backgroundColor": "red",
-        "borderRadius": 28,
+        "borderRadius": 26,
         "height": 52,
         "justifyContent": "center",
         "margin": 7,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1038,6 +1038,13 @@ export interface IconProps {
   reverse?: boolean;
 
   /**
+   * Specify reverse icon ratio
+   *
+   * @default 2
+   */
+  reverseRatio?: number;
+
+  /**
    * Adds box shadow to button
    *
    * @default false


### PR DESCRIPTION
Hi ! 😊
This is just a little useful feature to control the reverse ratio of an Icon.

### Example

| reverseRatio | Preview |
|--------------|---------|
| 1            |<img width="104" alt="capture d ecran 2018-12-14 a 11 52 48" src="https://user-images.githubusercontent.com/17292331/49999988-7ce08180-ff98-11e8-919c-6721ebe9be57.png">|
| 1.5 (default)          |<img width="140" alt="capture d ecran 2018-12-14 a 11 52 59" src="https://user-images.githubusercontent.com/17292331/50000000-84078f80-ff98-11e8-8faa-39cad5f0f7b7.png">|
| 2            |<img width="167" alt="capture d ecran 2018-12-14 a 11 53 10" src="https://user-images.githubusercontent.com/17292331/50000014-8e298e00-ff98-11e8-995e-2da6f8a3f6a9.png">|

You get the idea ! 😘


