### PR TITLE
feat(Slider): Add ability to put an image on the thumb with specific styles. Uses react-native Image.

### DIFF
--- a/src/slider/Slider.js
+++ b/src/slider/Slider.js
@@ -1,7 +1,14 @@
 /* eslint-disable no-underscore-dangle */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, Animated, Easing, PanResponder } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  Animated,
+  Easing,
+  PanResponder,
+  Image,
+} from 'react-native';
 
 import { ViewPropTypes, withTheme } from '../config';
 
@@ -358,6 +365,16 @@ class Slider extends Component {
     ];
   }
 
+  renderThumbImage() {
+    const { thumbImage, thumbImageStyle } = this.props;
+
+    if (thumbImage) {
+      return <Image source={thumbImage} style={thumbImageStyle} />;
+    }
+
+    return null;
+  }
+
   render() {
     const {
       minimumValue,
@@ -365,10 +382,12 @@ class Slider extends Component {
       minimumTrackTintColor,
       maximumTrackTintColor,
       thumbTintColor,
+      thumbImage,
       containerStyle,
       style,
       trackStyle,
       thumbStyle,
+      thumbImageStyle,
       debugTouchArea,
       orientation,
       ...other
@@ -447,11 +466,14 @@ class Slider extends Component {
               ...valueVisibleStyle,
             },
           ])}
-        />
+        >
+          {this.renderThumbImage()}
+        </Animated.View>
         <View
           style={StyleSheet.flatten([styles.touchArea, touchOverflowStyle])}
           {...this.panResponder.panHandlers}
         >
+          {thumbImage && <Image source={thumbImage} style={thumbImageStyle} />}
           {debugTouchArea === true &&
             this.renderDebugThumbTouchRect(thumbStart)}
         </View>
@@ -511,6 +533,11 @@ Slider.propTypes = {
   thumbTintColor: PropTypes.string,
 
   /**
+   * The image used for the thumb.
+   */
+  thumbImage: Image.propTypes.source,
+
+  /**
    * The size of the touch area that allows moving the thumb.
    * The touch area has the same center has the visible thumb.
    * This allows to have a visually small thumb while still allowing the user
@@ -555,6 +582,11 @@ Slider.propTypes = {
   thumbStyle: ViewPropTypes.style,
 
   /**
+   * The style appiled to the thumb image.
+   */
+  thumbImageStyle: ViewPropTypes.style,
+
+  /**
    * Set this to true to visually see the thumb touch rect in green.
    */
   debugTouchArea: PropTypes.bool,
@@ -589,6 +621,7 @@ Slider.defaultProps = {
   minimumTrackTintColor: '#3f3f3f',
   maximumTrackTintColor: '#b3b3b3',
   thumbTintColor: 'red',
+  thumbImage: null,
   thumbTouchSize: { width: 40, height: 40 },
   debugTouchArea: false,
   animationType: 'timing',

--- a/src/slider/Slider.js
+++ b/src/slider/Slider.js
@@ -382,12 +382,10 @@ class Slider extends Component {
       minimumTrackTintColor,
       maximumTrackTintColor,
       thumbTintColor,
-      thumbImage,
       containerStyle,
       style,
       trackStyle,
       thumbStyle,
-      thumbImageStyle,
       debugTouchArea,
       orientation,
       ...other
@@ -473,7 +471,6 @@ class Slider extends Component {
           style={StyleSheet.flatten([styles.touchArea, touchOverflowStyle])}
           {...this.panResponder.panHandlers}
         >
-          {thumbImage && <Image source={thumbImage} style={thumbImageStyle} />}
           {debugTouchArea === true &&
             this.renderDebugThumbTouchRect(thumbStart)}
         </View>
@@ -621,7 +618,7 @@ Slider.defaultProps = {
   minimumTrackTintColor: '#3f3f3f',
   maximumTrackTintColor: '#b3b3b3',
   thumbTintColor: 'red',
-  thumbImage: null,
+  thumbImage: undefined,
   thumbTouchSize: { width: 40, height: 40 },
   debugTouchArea: false,
   animationType: 'timing',

--- a/src/slider/__tests__/Slider.js
+++ b/src/slider/__tests__/Slider.js
@@ -58,6 +58,39 @@ describe('Slider component', () => {
     expect(toJson(component)).toMatchSnapshot();
   });
 
+  it('should render thumbImage', () => {
+    const component = shallow(
+      <Slider
+        thumbImage={{
+          uri:
+            'https://facebook.github.io/react-native/docs/assets/favicon.png',
+        }}
+      />
+    );
+
+    expect(component.length).toBe(1);
+  });
+
+  it('should not render thumbImage', () => {
+    const component = shallow(<Slider thumbImage={undefined} />);
+
+    expect(component.length).toBe(1);
+  });
+
+  it('should render thumbImage with styles', () => {
+    const component = shallow(
+      <Slider
+        thumbImage={{
+          uri:
+            'https://facebook.github.io/react-native/docs/assets/favicon.png',
+        }}
+        thumbImageStyle={{ width: 20, height: 20 }}
+      />
+    );
+
+    expect(component.length).toBe(1);
+  });
+
   it('should call onValueChange', () => {
     const customFunction = jest.fn();
     const component = shallow(


### PR DESCRIPTION
Issue for reference: https://github.com/react-native-training/react-native-elements/issues/1394
Checks for optional thumbImage with styling and renders accordingly. Uses react-native [Image](https://facebook.github.io/react-native/docs/image).