### PR TITLE
feat(Icon): Use platform Touchable

### DIFF
--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -6,7 +6,9 @@ import {
   View,
   StyleSheet,
   Text as NativeText,
+  TouchableNativeFeedback,
 } from 'react-native';
+import Color from 'color';
 
 import getIconType from '../helpers/getIconType';
 import { ViewPropTypes, withTheme } from '../config';
@@ -26,7 +28,12 @@ const Icon = props => {
     disabled,
     disabledStyle,
     onPress,
-    Component = onPress ? TouchableHighlight : View,
+    Component = onPress
+      ? Platform.select({
+          android: TouchableNativeFeedback,
+          default: TouchableHighlight,
+        })
+      : View,
     ...attributes
   } = props;
 
@@ -39,40 +46,71 @@ const Icon = props => {
     return raised ? 'white' : 'transparent';
   };
 
+  const buttonStyles = {
+    borderRadius: size + 4,
+    height: size * 2 + 4,
+    width: size * 2 + 4,
+  };
+
+  if (Platform.OS === 'android' && !attributes.background) {
+    if (Platform.Version >= 21) {
+      attributes.background = TouchableNativeFeedback.Ripple(
+        Color(color)
+          .alpha(0.2)
+          .rgb()
+          .string(),
+        true
+      );
+    }
+  }
+
   return (
-    <View style={containerStyle && containerStyle}>
+    <View
+      style={StyleSheet.flatten([
+        styles.container,
+        (reverse || raised) && styles.button,
+        (reverse || raised) && buttonStyles,
+        raised && styles.raised,
+        iconStyle && iconStyle.borderRadius
+          ? {
+              borderRadius: iconStyle.borderRadius,
+            }
+          : {},
+        containerStyle && containerStyle,
+      ])}
+    >
       <Component
         {...attributes}
-        underlayColor={reverse ? color : underlayColor || color}
-        style={StyleSheet.flatten([
-          (reverse || raised) && styles.button,
-          (reverse || raised) && {
-            borderRadius: size + 4,
-            height: size * 2 + 4,
-            width: size * 2 + 4,
-          },
-          raised && styles.raised,
-          {
-            backgroundColor: getBackgroundColor(),
-            alignItems: 'center',
-            justifyContent: 'center',
-          },
-          disabled && styles.disabled,
-          disabled && disabledStyle,
-        ])}
-        {...onPress && { disabled }}
-        onPress={onPress}
+        {...onPress && {
+          onPress,
+          disabled,
+          underlayColor: reverse ? color : underlayColor,
+          activeOpacity: 0.3,
+        }}
       >
-        <IconComponent
-          testID="iconIcon"
+        <View
           style={StyleSheet.flatten([
-            { backgroundColor: 'transparent' },
-            iconStyle && iconStyle,
+            (reverse || raised) && buttonStyles,
+            {
+              backgroundColor: getBackgroundColor(),
+              alignItems: 'center',
+              justifyContent: 'center',
+            },
+            disabled && styles.disabled,
+            disabled && disabledStyle,
           ])}
-          size={size}
-          name={name}
-          color={reverse ? reverseColor : color}
-        />
+        >
+          <IconComponent
+            testID="iconIcon"
+            style={StyleSheet.flatten([
+              { backgroundColor: 'transparent' },
+              iconStyle && iconStyle,
+            ])}
+            size={size}
+            name={name}
+            color={reverse ? reverseColor : color}
+          />
+        </View>
       </Component>
     </View>
   );
@@ -96,7 +134,7 @@ Icon.propTypes = {
 };
 
 Icon.defaultProps = {
-  underlayColor: 'white',
+  underlayColor: 'transparent',
   reverse: false,
   raised: false,
   size: 24,
@@ -107,6 +145,9 @@ Icon.defaultProps = {
 };
 
 const styles = StyleSheet.create({
+  container: {
+    overflow: 'hidden',
+  },
   button: {
     margin: 7,
   },

--- a/src/icons/__tests__/Icon.js
+++ b/src/icons/__tests__/Icon.js
@@ -22,7 +22,8 @@ describe('Icon component', () => {
         type="octicon"
         reverse
         color="red"
-        iconStyle={{ backgroundColor: 'peru' }}
+        iconStyle={{ backgroundColor: 'peru', borderRadius: 30 }}
+        onPress={jest.fn()}
       />
     );
 
@@ -77,6 +78,19 @@ describe('Icon component', () => {
 
   it('should apply raised styles', () => {
     const component = shallow(<Icon name="wifi" raised />);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('works on android with onPress', () => {
+    jest.mock('Platform', () => ({
+      OS: 'android',
+      Version: 25,
+      select(obj) {
+        return obj.android;
+      },
+    }));
+
+    const component = shallow(<Icon name="wifi" onPress={jest.fn()} />);
     expect(toJson(component)).toMatchSnapshot();
   });
 

--- a/src/icons/__tests__/__snapshots__/Icon.js.snap
+++ b/src/icons/__tests__/__snapshots__/Icon.js.snap
@@ -5,181 +5,221 @@ exports[`Icon component should apply container style 1`] = `
   style={
     Object {
       "backgroundColor": "blue",
+      "overflow": "hidden",
     }
   }
 >
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "transparent",
-        "justifyContent": "center",
-      }
-    }
-    underlayColor="white"
-  >
-    <Icon
-      allowFontScaling={false}
-      color="black"
-      name="wifi"
-      size={24}
+  <View>
+    <View
       style={
         Object {
+          "alignItems": "center",
           "backgroundColor": "transparent",
+          "justifyContent": "center",
         }
       }
-      testID="iconIcon"
-    />
+    >
+      <Icon
+        allowFontScaling={false}
+        color="black"
+        name="wifi"
+        size={24}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+          }
+        }
+        testID="iconIcon"
+      />
+    </View>
   </View>
 </View>
 `;
 
 exports[`Icon component should apply custom disabled styles 1`] = `
-<View>
+<View
+  style={
+    Object {
+      "overflow": "hidden",
+    }
+  }
+>
   <TouchableHighlight
-    activeOpacity={0.85}
+    activeOpacity={0.3}
     delayPressOut={100}
     disabled={true}
     onPress={[MockFunction]}
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "pink",
-        "justifyContent": "center",
-      }
-    }
-    underlayColor="white"
+    underlayColor="transparent"
   >
-    <Icon
-      allowFontScaling={false}
-      color="black"
-      name="wifi"
-      size={24}
+    <View
       style={
         Object {
-          "backgroundColor": "transparent",
+          "alignItems": "center",
+          "backgroundColor": "pink",
+          "justifyContent": "center",
         }
       }
-      testID="iconIcon"
-    />
+    >
+      <Icon
+        allowFontScaling={false}
+        color="black"
+        name="wifi"
+        size={24}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+          }
+        }
+        testID="iconIcon"
+      />
+    </View>
   </TouchableHighlight>
 </View>
 `;
 
 exports[`Icon component should apply default disabled styles 1`] = `
-<View>
+<View
+  style={
+    Object {
+      "overflow": "hidden",
+    }
+  }
+>
   <TouchableHighlight
-    activeOpacity={0.85}
+    activeOpacity={0.3}
     delayPressOut={100}
     disabled={true}
     onPress={[MockFunction]}
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#D1D5D8",
-        "justifyContent": "center",
-      }
-    }
-    underlayColor="white"
+    underlayColor="transparent"
   >
-    <Icon
-      allowFontScaling={false}
-      color="black"
-      name="wifi"
-      size={24}
+    <View
       style={
         Object {
-          "backgroundColor": "transparent",
+          "alignItems": "center",
+          "backgroundColor": "#D1D5D8",
+          "justifyContent": "center",
         }
       }
-      testID="iconIcon"
-    />
+    >
+      <Icon
+        allowFontScaling={false}
+        color="black"
+        name="wifi"
+        size={24}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+          }
+        }
+        testID="iconIcon"
+      />
+    </View>
   </TouchableHighlight>
 </View>
 `;
 
 exports[`Icon component should apply raised styles 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "white",
-        "borderRadius": 28,
-        "height": 52,
-        "justifyContent": "center",
-        "margin": 7,
-        "shadowColor": "rgba(0,0,0, .4)",
-        "shadowOffset": Object {
-          "height": 1,
-          "width": 1,
-        },
-        "shadowOpacity": 1,
-        "shadowRadius": 1,
-        "width": 52,
-      }
+<View
+  style={
+    Object {
+      "borderRadius": 28,
+      "height": 52,
+      "margin": 7,
+      "overflow": "hidden",
+      "shadowColor": "rgba(0,0,0, .4)",
+      "shadowOffset": Object {
+        "height": 1,
+        "width": 1,
+      },
+      "shadowOpacity": 1,
+      "shadowRadius": 1,
+      "width": 52,
     }
-    underlayColor="white"
-  >
-    <Icon
-      allowFontScaling={false}
-      color="black"
-      name="wifi"
-      size={24}
+  }
+>
+  <View>
+    <View
       style={
         Object {
-          "backgroundColor": "transparent",
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "borderRadius": 28,
+          "height": 52,
+          "justifyContent": "center",
+          "width": 52,
         }
       }
-      testID="iconIcon"
-    />
+    >
+      <Icon
+        allowFontScaling={false}
+        color="black"
+        name="wifi"
+        size={24}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+          }
+        }
+        testID="iconIcon"
+      />
+    </View>
   </View>
 </View>
 `;
 
 exports[`Icon component should apply reverse styles 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "black",
-        "borderRadius": 28,
-        "height": 52,
-        "justifyContent": "center",
-        "margin": 7,
-        "width": 52,
-      }
+<View
+  style={
+    Object {
+      "borderRadius": 28,
+      "height": 52,
+      "margin": 7,
+      "overflow": "hidden",
+      "width": 52,
     }
-    underlayColor="black"
-  >
-    <Icon
-      allowFontScaling={false}
-      color="white"
-      name="wifi"
-      size={24}
+  }
+>
+  <View>
+    <View
       style={
         Object {
-          "backgroundColor": "transparent",
+          "alignItems": "center",
+          "backgroundColor": "black",
+          "borderRadius": 28,
+          "height": 52,
+          "justifyContent": "center",
+          "width": 52,
         }
       }
-      testID="iconIcon"
-    />
+    >
+      <Icon
+        allowFontScaling={false}
+        color="white"
+        name="wifi"
+        size={24}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+          }
+        }
+        testID="iconIcon"
+      />
+    </View>
   </View>
 </View>
 `;
 
 exports[`Icon component should apply values from theme 1`] = `
-<View>
-  <View
-    replaceTheme={[Function]}
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "transparent",
-        "justifyContent": "center",
-      }
+<View
+  style={
+    Object {
+      "overflow": "hidden",
     }
+  }
+>
+  <View
+    background={Object {}}
+    replaceTheme={[Function]}
     theme={
       Object {
         "Icon": Object {
@@ -220,120 +260,201 @@ exports[`Icon component should apply values from theme 1`] = `
         },
       }
     }
-    underlayColor="white"
     updateTheme={[Function]}
   >
-    <Text
-      allowFontScaling={false}
+    <View
       style={
-        Array [
-          Object {
-            "color": "black",
-            "fontSize": 26,
-          },
-          Object {
-            "backgroundColor": "transparent",
-          },
-          Object {
-            "fontFamily": "Material Icons",
-            "fontStyle": "normal",
-            "fontWeight": "normal",
-          },
-          Object {},
-        ]
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "transparent",
+          "justifyContent": "center",
+        }
       }
-      testID="iconIcon"
     >
-      
-    </Text>
+      <Text
+        allowFontScaling={false}
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 26,
+            },
+            Object {
+              "backgroundColor": "transparent",
+            },
+            Object {
+              "fontFamily": "Material Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
+          ]
+        }
+        testID="iconIcon"
+      >
+        
+      </Text>
+    </View>
   </View>
 </View>
 `;
 
 exports[`Icon component should render with icon type 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "red",
-        "borderRadius": 28,
-        "height": 52,
-        "justifyContent": "center",
-        "margin": 7,
-        "width": 52,
-      }
+<View
+  style={
+    Object {
+      "borderRadius": 30,
+      "height": 52,
+      "margin": 7,
+      "overflow": "hidden",
+      "width": 52,
     }
+  }
+>
+  <TouchableHighlight
+    activeOpacity={0.3}
+    delayPressOut={100}
+    disabled={false}
+    onPress={[MockFunction]}
     underlayColor="red"
   >
-    <Icon
-      allowFontScaling={false}
-      color="white"
-      name="alert"
-      size={24}
+    <View
       style={
         Object {
-          "backgroundColor": "peru",
+          "alignItems": "center",
+          "backgroundColor": "red",
+          "borderRadius": 28,
+          "height": 52,
+          "justifyContent": "center",
+          "width": 52,
         }
       }
-      testID="iconIcon"
-    />
-  </View>
+    >
+      <Icon
+        allowFontScaling={false}
+        color="white"
+        name="alert"
+        size={24}
+        style={
+          Object {
+            "backgroundColor": "peru",
+            "borderRadius": 30,
+          }
+        }
+        testID="iconIcon"
+      />
+    </View>
+  </TouchableHighlight>
 </View>
 `;
 
 exports[`Icon component should render without issues 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "transparent",
-        "justifyContent": "center",
-      }
+<View
+  style={
+    Object {
+      "overflow": "hidden",
     }
-    underlayColor="white"
-  >
-    <Icon
-      allowFontScaling={false}
-      color="black"
-      name="wifi"
-      size={24}
+  }
+>
+  <View>
+    <View
       style={
         Object {
+          "alignItems": "center",
           "backgroundColor": "transparent",
+          "justifyContent": "center",
         }
       }
-      testID="iconIcon"
-    />
+    >
+      <Icon
+        allowFontScaling={false}
+        color="black"
+        name="wifi"
+        size={24}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+          }
+        }
+        testID="iconIcon"
+      />
+    </View>
   </View>
 </View>
 `;
 
 exports[`Icon component should set underlayColor to color when styles when underlayColor absent 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "transparent",
-        "justifyContent": "center",
-      }
+<View
+  style={
+    Object {
+      "overflow": "hidden",
     }
-    underlayColor="black"
-  >
-    <Icon
-      allowFontScaling={false}
-      color="black"
-      name="wifi"
-      size={24}
+  }
+>
+  <View>
+    <View
       style={
         Object {
+          "alignItems": "center",
           "backgroundColor": "transparent",
+          "justifyContent": "center",
         }
       }
-      testID="iconIcon"
-    />
+    >
+      <Icon
+        allowFontScaling={false}
+        color="black"
+        name="wifi"
+        size={24}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+          }
+        }
+        testID="iconIcon"
+      />
+    </View>
   </View>
+</View>
+`;
+
+exports[`Icon component works on android with onPress 1`] = `
+<View
+  style={
+    Object {
+      "overflow": "hidden",
+    }
+  }
+>
+  <DummyTouchableNativeFeedback
+    activeOpacity={0.3}
+    background={Object {}}
+    disabled={false}
+    onPress={[MockFunction]}
+    underlayColor="transparent"
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "transparent",
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Icon
+        allowFontScaling={false}
+        color="black"
+        name="wifi"
+        size={24}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+          }
+        }
+        testID="iconIcon"
+      />
+    </View>
+  </DummyTouchableNativeFeedback>
 </View>
 `;

--- a/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
+++ b/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
@@ -332,16 +332,15 @@ exports[`PricingCard component should apply values from theme 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "overflow": "hidden",
+              }
+            }
+          >
             <View
               replaceTheme={[Function]}
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "justifyContent": "center",
-                }
-              }
               theme={
                 Object {
                   "PricingCard": Object {
@@ -382,32 +381,41 @@ exports[`PricingCard component should apply values from theme 1`] = `
                   },
                 }
               }
-              underlayColor="white"
               updateTheme={[Function]}
             >
-              <Text
-                allowFontScaling={false}
+              <View
                 style={
-                  Array [
-                    Object {
-                      "color": "white",
-                      "fontSize": 15,
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                    Object {
-                      "fontFamily": "Material Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
+                  Object {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "justifyContent": "center",
+                  }
                 }
-                testID="iconIcon"
               >
-                
-              </Text>
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "white",
+                        "fontSize": 15,
+                      },
+                      Object {
+                        "backgroundColor": "transparent",
+                      },
+                      Object {
+                        "fontFamily": "Material Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                  testID="iconIcon"
+                >
+                  
+                </Text>
+              </View>
             </View>
           </View>
           <Text

--- a/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
@@ -44,16 +44,15 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
           }
         }
       >
-        <View>
+        <View
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
+        >
           <View
             replaceTheme={[Function]}
-            style={
-              Object {
-                "alignItems": "center",
-                "backgroundColor": "transparent",
-                "justifyContent": "center",
-              }
-            }
             theme={
               Object {
                 "SearchBar": Object {
@@ -94,32 +93,41 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
                 },
               }
             }
-            underlayColor="white"
             updateTheme={[Function]}
           >
-            <Text
-              allowFontScaling={false}
+            <View
               style={
-                Array [
-                  Object {
-                    "color": "rgba(0, 0, 0, 0.54)",
-                    "fontSize": 25,
-                  },
-                  Object {
-                    "backgroundColor": "transparent",
-                  },
-                  Object {
-                    "fontFamily": "Material Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "justifyContent": "center",
+                }
               }
-              testID="iconIcon"
             >
-              
-            </Text>
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "color": "rgba(0, 0, 0, 0.54)",
+                      "fontSize": 25,
+                    },
+                    Object {
+                      "backgroundColor": "transparent",
+                    },
+                    Object {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    Object {},
+                  ]
+                }
+                testID="iconIcon"
+              >
+                
+              </Text>
+            </View>
           </View>
         </View>
       </View>


### PR DESCRIPTION
Allows using TouchableNativeFeedback on android, and TouchableHighlight on web and iOS.

None of the breaking changes below break your app, but the look might change depending on the props used.

BREAKING CHANGES:
- No longer uses TouchableHighlight on android by default.
- Default underlay color is now transparent instead of white
- activeOpacity previously not set is now 0.3

Resolves #2027