### PR TITLE
ci: Only deploy website changes from next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - yarn run test:ci && codecov
 after_success:
   - |
-    if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [[ "$TRAVIS_BRANCH" == "master" || "$TRAVIS_BRANCH" == "next" ]]; then
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ] && ["$TRAVIS_BRANCH" == "next" ]; then
       git config --global user.name "React Native Elements CI"
       echo -e "machine github.com\n login react-native-elements-ci\n password $GITHUB_TOKEN" >> ~/.netrc
       cd website && yarn && GIT_USER=react-native-elements-ci yarn run publish-gh-pages


### PR DESCRIPTION
When having both next and master, changes on master would then override the new additions made on next.