### PR TITLE
feat(Image): Add transition prop

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -40,6 +40,7 @@ import { Image } from 'react-native-elements';
 
 - [`containerStyle`](#containerstyle)
 - [`placeholderStyle`](#placeholderstyle)
+- [`transition`](#transition)
 - [`PlaceholderContent`](#placeholdercontent)
 - [`ImageComponent`](#imagecomponent)
 
@@ -64,6 +65,16 @@ Additional styling for the placeholder container (optional)
 |        Type         | Default |
 | :-----------------: | :-----: |
 | View style (object) |  none   |
+
+---
+
+### `transition`
+
+Perform fade transition on image load
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  true   |
 
 ---
 

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -162,7 +162,6 @@ const styles = StyleSheet.create({
   },
   overlayContainer: {
     flex: 1,
-    backgroundColor: '#bdbdbd',
   },
   title: {
     color: '#ffffff',

--- a/src/avatar/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/avatar/__tests__/__snapshots__/Avatar.js.snap
@@ -14,7 +14,6 @@ exports[`Avatar Component Edit button android 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -85,7 +84,6 @@ exports[`Avatar Component Edit button ios 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -169,7 +167,6 @@ exports[`Avatar Component Placeholders renders using icon prop 1`] = `
     }
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -216,7 +213,6 @@ exports[`Avatar Component Placeholders renders using icon with defaults 1`] = `
     }
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -299,7 +295,6 @@ exports[`Avatar Component Sizes accepts a number 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -334,7 +329,6 @@ exports[`Avatar Component Sizes accepts large 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -369,7 +363,6 @@ exports[`Avatar Component Sizes accepts medium 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -404,7 +397,6 @@ exports[`Avatar Component Sizes accepts small 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -439,7 +431,6 @@ exports[`Avatar Component Sizes accepts xlarge 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -474,7 +465,6 @@ exports[`Avatar Component Sizes defaults to small if invalid string given 1`] = 
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -509,7 +499,6 @@ exports[`Avatar Component allows custom imageProps 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -546,7 +535,6 @@ exports[`Avatar Component renders rounded 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "borderRadius": 17,
         "flex": 1,
         "overflow": "hidden",
@@ -585,7 +573,6 @@ exports[`Avatar Component renders touchable if onPress given 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }
@@ -664,7 +651,7 @@ exports[`Avatar Component should apply values from theme 1`] = `
     accessibilityIgnoresInvertColors={true}
     style={
       Object {
-        "backgroundColor": "#bdbdbd",
+        "backgroundColor": "transparent",
         "flex": 1,
         "position": "relative",
       }
@@ -736,6 +723,7 @@ exports[`Avatar Component should apply values from theme 1`] = `
           },
         }
       }
+      transition={true}
       updateTheme={[Function]}
     />
     <View
@@ -794,7 +782,6 @@ exports[`Avatar Component should render without issues 1`] = `
     ImageComponent={[Function]}
     containerStyle={
       Object {
-        "backgroundColor": "#bdbdbd",
         "flex": 1,
       }
     }

--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -17,6 +17,11 @@ class Image extends React.Component {
   };
 
   onLoad = () => {
+    if (!this.props.transition) {
+      this.state.placeholderOpacity.setValue(0);
+      return;
+    }
+
     const minimumWait = 100;
     const staggerNonce = 200 * Math.random();
 
@@ -112,11 +117,13 @@ Image.propTypes = {
   PlaceholderContent: nodeType,
   containerStyle: ViewPropTypes.style,
   placeholderStyle: ImageNative.propTypes.style,
+  transition: PropTypes.bool,
 };
 
 Image.defaultProps = {
   ImageComponent: ImageNative,
   style: {},
+  transition: true,
 };
 
 export { Image };

--- a/src/image/__tests__/Image.js
+++ b/src/image/__tests__/Image.js
@@ -90,4 +90,17 @@ describe('Image Component', () => {
     ).toBe('red');
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it('should render without the transition', () => {
+    const component = shallow(
+      <Image
+        source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
+        transition={false}
+      />
+    );
+
+    component.find({ testID: 'RNE__Image' }).prop('onLoad')();
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
 });

--- a/src/image/__tests__/__snapshots__/Image.js.snap
+++ b/src/image/__tests__/__snapshots__/Image.js.snap
@@ -76,6 +76,7 @@ exports[`Image Component should apply values from theme 1`] = `
         },
       }
     }
+    transition={true}
     updateTheme={[Function]}
   />
   <View
@@ -143,6 +144,7 @@ exports[`Image Component should render on android 1`] = `
       ]
     }
     testID="RNE__Image"
+    transition={true}
   />
   <AnimatedComponent
     accessibilityElementsHidden={true}
@@ -213,6 +215,7 @@ exports[`Image Component should render on ios 1`] = `
       ]
     }
     testID="RNE__Image"
+    transition={true}
   />
   <AnimatedComponent
     accessibilityElementsHidden={true}

--- a/src/image/__tests__/__snapshots__/Image.js.snap
+++ b/src/image/__tests__/__snapshots__/Image.js.snap
@@ -252,3 +252,74 @@ exports[`Image Component should render on ios 1`] = `
   />
 </View>
 `;
+
+exports[`Image Component should render without the transition 1`] = `
+<View
+  accessibilityIgnoresInvertColors={true}
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "position": "relative",
+    }
+  }
+>
+  <Image
+    onLoad={[Function]}
+    source={
+      Object {
+        "uri": "https://i.imgur.com/0y8Ftya.jpg",
+      }
+    }
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {
+          "height": undefined,
+          "width": undefined,
+        },
+      ]
+    }
+    testID="RNE__Image"
+    transition={false}
+  />
+  <AnimatedComponent
+    accessibilityElementsHidden={true}
+    importantForAccessibility="no-hide-descendants"
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {
+          "opacity": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#bdbdbd",
+          "justifyContent": "center",
+        }
+      }
+      testID="RNE__Image__placeholder"
+    />
+  </AnimatedComponent>
+  <View
+    style={Object {}}
+  />
+</View>
+`;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -233,7 +233,7 @@ export interface AvatarProps {
  * Avatar Component
  *
  */
-export class Avatar extends React.Component<AvatarProps, any> {}
+export class Avatar extends React.Component<AvatarProps> {}
 
 export interface ButtonProps
   extends TouchableOpacityProps,
@@ -1941,6 +1941,13 @@ export interface ImageProps extends RNImageProps {
    * Additional styling for the placeholder container
    */
   placeholderStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Perform fade transition on image load
+   *
+   * @default true
+   */
+  transition?: boolean;
 }
 
 /**

--- a/src/tile/__tests__/__snapshots__/Tile.js.snap
+++ b/src/tile/__tests__/__snapshots__/Tile.js.snap
@@ -162,6 +162,7 @@ exports[`Tile component should apply styles from theme 1`] = `
           },
         }
       }
+      transition={true}
       updateTheme={[Function]}
     />
     <View


### PR DESCRIPTION
New `transition` prop that can be used to disable the fade transition on the Image component and surrounding components - Avatar, ListItem, Tile.

Resolves #2004

To use from Avatar, simply use the `imageProps` prop. e.g.

```jsx
<Avatar imageProps={{ transition: false }} />
```

![Kapture 2019-10-14 at 0 09 06](https://user-images.githubusercontent.com/5962998/66729530-03b0f580-ee1a-11e9-9467-6ab9d103e4f6.gif)
