### PR TITLE
feat(Icon): Add support for FontAwesome5

### DIFF
--- a/docs/icon.md
+++ b/docs/icon.md
@@ -18,7 +18,8 @@ The current list of available icons sets are:
 
 - [material](https://material.io/tools/icons)
 - [material-community](https://materialdesignicons.com/)
-- [font-awesome](http://fontawesome.io/icons/)
+- [font-awesome](https://fontawesome.com/v4.7.0/)
+- [font-awesome-5](https://fontawesome.com/)
 - [octicon](https://octicons.github.com/)
 - [ionicon](http://ionicons.com/)
 - [foundation](http://zurb.com/playground/foundation-icon-fonts-3)
@@ -80,53 +81,35 @@ import { Icon } from 'react-native-elements'
 
 ## Props
 
+- [`brand`](#brand)
 - [`color`](#color)
 - [`containerStyle`](#containerstyle)
-- [`Component`](#Component)
 - [`disabled`](#disabled)
 - [`disabledStyle`](#disabledstyle)
-- [`onPress`](#onpress)
 - [`iconStyle`](#iconstyle)
 - [`name`](#name)
+- [`onPress`](#onpress)
 - [`onLongPress`](#onlongpress)
 - [`raised`](#raised)
 - [`reverse`](#reverse)
 - [`reverseColor`](#reversecolor)
 - [`size`](#size)
+- [`solid`](#solid)
 - [`type`](#type)
 - [`underlayColor`](#underlaycolor)
+- [`Component`](#Component)
 
 ---
 
 ## Reference
 
-### `name`
+### `brand`
 
-name of icon (required)
+Uses the brands font (FontAwesome5 only)
 
-|  Type  | Default |
-| :----: | :-----: |
-| string |  none   |
-
----
-
-### `type`
-
-type of icon set. [Supported sets here](#available-icon-sets).
-
-|  Type  | Default  |
-| :----: | :------: |
-| string | material |
-
----
-
-### `size`
-
-size of icon (optional)
-
-|  Type  | Default |
-| :----: | :-----: |
-| number |   26    |
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
 
 ---
 
@@ -140,23 +123,13 @@ color of icon (optional)
 
 ---
 
-### `iconStyle`
+### `containerStyle`
 
-additional styling to icon (optional)
+add styling to container holding icon (optional)
 
-|      Type      |     Default     |
-| :------------: | :-------------: |
-| object (style) | inherited style |
-
----
-
-### `Component`
-
-update React Native Component (optional)
-
-|          Type          |                                        Default                                        |
-| :--------------------: | :-----------------------------------------------------------------------------------: |
-| React Native component | View if no onPress method is defined, TouchableHighlight if onPress method is defined |
+|        Type         |      Default      |
+| :-----------------: | :---------------: |
+| View style (object) | inherited styling |
 
 ---
 
@@ -175,9 +148,29 @@ Disables onPress events (optional). Only works when `onPress` has a handler.
 Style for the button when disabled (optional). Only works when `onPress` has a
 handler.
 
-|  Type   |              Default               |
-| :-----: | :--------------------------------: |
-| boolean | `{{ backgroundColor: '#D1D5D8' }}` |
+|        Type         |              Default               |
+| :-----------------: | :--------------------------------: |
+| View style (object) | `{{ backgroundColor: '#D1D5D8' }}` |
+
+---
+
+### `iconStyle`
+
+additional styling to icon (optional)
+
+|        Type         |     Default     |
+| :-----------------: | :-------------: |
+| View style (object) | inherited style |
+
+---
+
+### `name`
+
+name of icon (required)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
 
 ---
 
@@ -201,13 +194,13 @@ onLongPress method for button (optional)
 
 ---
 
-### `underlayColor`
+### `raised`
 
-underlayColor for press event
+adds box shadow to button (optional)
 
-|  Type  |  Default   |
-| :----: | :--------: |
-| string | icon color |
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
 
 ---
 
@@ -221,26 +214,6 @@ reverses color scheme (optional)
 
 ---
 
-### `raised`
-
-adds box shadow to button (optional)
-
-|  Type   | Default |
-| :-----: | :-----: |
-| boolean |  false  |
-
----
-
-### `containerStyle`
-
-add styling to container holding icon (optional)
-
-|      Type      |      Default      |
-| :------------: | :---------------: |
-| object (style) | inherited styling |
-
----
-
 ### `reverseColor`
 
 specify reverse icon color (optional)
@@ -248,3 +221,53 @@ specify reverse icon color (optional)
 |  Type  | Default |
 | :----: | :-----: |
 | string |  white  |
+
+---
+
+### `size`
+
+size of icon (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   26    |
+
+---
+
+### `solid`
+
+Uses the solid font (FontAwesome5 only)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `type`
+
+type of icon set. [Supported sets here](#available-icon-sets).
+
+|  Type  | Default  |
+| :----: | :------: |
+| string | material |
+
+---
+
+### `underlayColor`
+
+underlayColor for press event
+
+|  Type  |  Default   |
+| :----: | :--------: |
+| string | icon color |
+
+---
+
+### `Component`
+
+update React Native Component (optional)
+
+|          Type          |                                        Default                                        |
+| :--------------------: | :-----------------------------------------------------------------------------------: |
+| React Native component | View if no onPress method is defined, TouchableHighlight if onPress method is defined |

--- a/src/helpers/getIconType.js
+++ b/src/helpers/getIconType.js
@@ -7,6 +7,7 @@ import FoundationIcon from 'react-native-vector-icons/Foundation';
 import EvilIcon from 'react-native-vector-icons/EvilIcons';
 import EntypoIcon from 'react-native-vector-icons/Entypo';
 import FAIcon from 'react-native-vector-icons/FontAwesome';
+import FA5Icon from 'react-native-vector-icons/FontAwesome5';
 import SimpleLineIcon from 'react-native-vector-icons/SimpleLineIcons';
 import FeatherIcon from 'react-native-vector-icons/Feather';
 import AntIcon from 'react-native-vector-icons/AntDesign';
@@ -37,6 +38,8 @@ export default type => {
       return EntypoIcon;
     case 'font-awesome':
       return FAIcon;
+    case 'font-awesome-5':
+      return FA5Icon;
     case 'simple-line-icon':
       return SimpleLineIcon;
     case 'feather':

--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -34,6 +34,8 @@ const Icon = props => {
           default: TouchableHighlight,
         })
       : View,
+    solid,
+    brand,
     ...attributes
   } = props;
 
@@ -109,6 +111,8 @@ const Icon = props => {
             size={size}
             name={name}
             color={reverse ? reverseColor : color}
+            solid={solid}
+            brand={brand}
           />
         </View>
       </Component>
@@ -131,6 +135,8 @@ Icon.propTypes = {
   reverseColor: PropTypes.string,
   disabled: PropTypes.bool,
   disabledStyle: ViewPropTypes.style,
+  solid: PropTypes.bool,
+  brand: PropTypes.bool,
 };
 
 Icon.defaultProps = {
@@ -142,6 +148,8 @@ Icon.defaultProps = {
   reverseColor: 'white',
   disabled: false,
   type: 'material',
+  solid: false,
+  brand: false,
 };
 
 const styles = StyleSheet.create({

--- a/src/icons/__tests__/__snapshots__/Icon.js.snap
+++ b/src/icons/__tests__/__snapshots__/Icon.js.snap
@@ -21,9 +21,11 @@ exports[`Icon component should apply container style 1`] = `
     >
       <Icon
         allowFontScaling={false}
+        brand={false}
         color="black"
         name="wifi"
         size={24}
+        solid={false}
         style={
           Object {
             "backgroundColor": "transparent",
@@ -62,9 +64,11 @@ exports[`Icon component should apply custom disabled styles 1`] = `
     >
       <Icon
         allowFontScaling={false}
+        brand={false}
         color="black"
         name="wifi"
         size={24}
+        solid={false}
         style={
           Object {
             "backgroundColor": "transparent",
@@ -103,9 +107,11 @@ exports[`Icon component should apply default disabled styles 1`] = `
     >
       <Icon
         allowFontScaling={false}
+        brand={false}
         color="black"
         name="wifi"
         size={24}
+        solid={false}
         style={
           Object {
             "backgroundColor": "transparent",
@@ -152,9 +158,11 @@ exports[`Icon component should apply raised styles 1`] = `
     >
       <Icon
         allowFontScaling={false}
+        brand={false}
         color="black"
         name="wifi"
         size={24}
+        solid={false}
         style={
           Object {
             "backgroundColor": "transparent",
@@ -194,9 +202,11 @@ exports[`Icon component should apply reverse styles 1`] = `
     >
       <Icon
         allowFontScaling={false}
+        brand={false}
         color="white"
         name="wifi"
         size={24}
+        solid={false}
         style={
           Object {
             "backgroundColor": "transparent",
@@ -273,6 +283,8 @@ exports[`Icon component should apply values from theme 1`] = `
     >
       <Text
         allowFontScaling={false}
+        brand={false}
+        solid={false}
         style={
           Array [
             Object {
@@ -332,9 +344,11 @@ exports[`Icon component should render with icon type 1`] = `
     >
       <Icon
         allowFontScaling={false}
+        brand={false}
         color="white"
         name="alert"
         size={24}
+        solid={false}
         style={
           Object {
             "backgroundColor": "peru",
@@ -368,9 +382,11 @@ exports[`Icon component should render without issues 1`] = `
     >
       <Icon
         allowFontScaling={false}
+        brand={false}
         color="black"
         name="wifi"
         size={24}
+        solid={false}
         style={
           Object {
             "backgroundColor": "transparent",
@@ -403,9 +419,11 @@ exports[`Icon component should set underlayColor to color when styles when under
     >
       <Icon
         allowFontScaling={false}
+        brand={false}
         color="black"
         name="wifi"
         size={24}
+        solid={false}
         style={
           Object {
             "backgroundColor": "transparent",
@@ -444,9 +462,11 @@ exports[`Icon component works on android with onPress 1`] = `
     >
       <Icon
         allowFontScaling={false}
+        brand={false}
         color="black"
         name="wifi"
         size={24}
+        solid={false}
         style={
           Object {
             "backgroundColor": "transparent",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -41,6 +41,7 @@ export type IconType =
   | 'evilicon'
   | 'entypo'
   | 'antdesign'
+  | 'font-awesome-5'
   | string;
 
 export interface IconObject {
@@ -1071,6 +1072,20 @@ export interface IconProps extends IconButtonProps {
    * Styles for the Icon when disabled
    */
   disabledStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * FontAwesome5 solid style
+   *
+   * @default false
+   */
+  solid?: boolean;
+
+  /**
+   * FontAwesome5 brands icon set
+   *
+   * @default false
+   */
+  brand?: boolean;
 }
 
 /**

--- a/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
+++ b/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
@@ -394,6 +394,8 @@ exports[`PricingCard component should apply values from theme 1`] = `
               >
                 <Text
                   allowFontScaling={false}
+                  brand={false}
+                  solid={false}
                   style={
                     Array [
                       Object {

--- a/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
@@ -106,6 +106,8 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
             >
               <Text
                 allowFontScaling={false}
+                brand={false}
+                solid={false}
                 style={
                   Array [
                     Object {


### PR DESCRIPTION
Allows using `font-awesome-5` anywhere icons are used. Also supports the brands, regular, and solid styles.

Resolves #1877 #1338