### PR TITLE
fixed unnecessary ThemProps in withTheme hoc

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2070,4 +2070,4 @@ export const ThemeContext: React.Context<ThemeProps<{}>>;
 
 export function withTheme<P = {}, T = {}>(
   component: React.ComponentType<P & ThemeProps<T>>
-): React.ComponentClass<P>;
+): React.ComponentClass<Omit<P, keyof ThemeProps<T>>>;


### PR DESCRIPTION
when I use withTheme

```js
import React from 'react'
import {ThemeProps, withTheme } from 'react-native-elements'

interface Props extends ThemeProps<any>{
   onPress: () => void
}

class Button extends React.Component {
   // ... rest of all
}

const ThemeButton = withTheme(Button)
```

```js
<ThemeButton 
  onPress={this.onPress}
/>
```

keep showing error about not providing required props `theme` `updateTheme` `replaceTheme`