### PR TITLE
refactor: Cleanup Overlay

### DIFF
--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -10,37 +10,27 @@ way to inform or request information from the user.
 
 ## Usage
 
-```js
-import { Overlay } from 'react-native-elements';
+```jsx
+import React, { useState } from 'react';
+import { Button, Overlay } from 'react-native-elements';
 
-<Overlay isVisible={this.state.isVisible}>
-  <Text>Hello from Overlay!</Text>
-</Overlay>;
+const OverlayExample = () => {
+  const [visible, setVisible] = useState(false);
 
-{
-  this.state.visible && (
-    <Overlay isVisible>
-      <Text>Hello from Overlay!</Text>
-    </Overlay>
+  const toggleOverlay = () => {
+    setVisible(!visible);
+  };
+
+  return (
+    <View>
+      <Button title="Open Overlay" onPress={toggleOverlay} />
+
+      <Overlay isVisible={visible} onBackdropPress={toggleOverlay}>
+        <Text>Hello from Overlay!</Text>
+      </Overlay>
+    </View>
   );
-}
-
-<Overlay
-  isVisible={this.state.isVisible}
-  windowBackgroundColor="rgba(255, 255, 255, .5)"
-  overlayBackgroundColor="red"
-  width="auto"
-  height="auto"
->
-  <Text>Hello from Overlay!</Text>
-</Overlay>;
-
-<Overlay
-  isVisible={this.state.isVisible}
-  onBackdropPress={() => this.setState({ isVisible: false })}
->
-  <Text>Hello from Overlay!</Text>
-</Overlay>;
+};
 ```
 
 ---
@@ -48,33 +38,18 @@ import { Overlay } from 'react-native-elements';
 ## Props
 
 > Also receives all
-> [Modal](https://facebook.github.io/react-native/docs/modal#props-1) props
+> [Modal](https://facebook.github.io/react-native/docs/modal#props) props
 
-- [`borderRadius`](#borderradius)
+- [`backdropStyle`](#backdropStyle)
 - [`children`](#children)
-- [`containerStyle`](#containerstyle)
 - [`fullScreen`](#fullscreen)
-- [`height`](#height)
 - [`isVisible`](#isvisible)
-- [`overlayBackgroundColor`](#overlaybackgroundcolor)
 - [`onBackdropPress`](#onbackdroppress)
 - [`overlayStyle`](#overlaystyle)
-- [`width`](#width)
-- [`windowBackgroundColor`](#windowbackgroundcolor)
 
 ---
 
 ## Reference
-
-### `borderRadius`
-
-Border radius for the overlay
-
-|  Type  | Default |
-| :----: | :-----: |
-| number |    3    |
-
----
 
 ### `children`
 
@@ -86,9 +61,9 @@ What the modal will render
 
 ---
 
-### `containerStyle`
+### `backdropStyle`
 
-Style of the overlay container
+Style of the backdrop container
 
 |        Type         |    Default     |
 | :-----------------: | :------------: |
@@ -106,16 +81,6 @@ If set to true, the modal will take up the entire screen width and height
 
 ---
 
-### `height`
-
-Height of the overlay
-
-|       Type       |       Default       |
-| :--------------: | :-----------------: |
-| string or number | window height - 180 |
-
----
-
 ### `isVisible`
 
 If true, the overlay is visible
@@ -123,16 +88,6 @@ If true, the overlay is visible
 |  Type   | Default |
 | :-----: | :-----: |
 | boolean |  false  |
-
----
-
-### `overlayBackgroundColor`
-
-Background color of the actual overlay
-
-|  Type  | Default |
-| :----: | :-----: |
-| string |  white  |
 
 ---
 
@@ -148,28 +103,8 @@ style of the actual overlay
 
 ### `onBackdropPress`
 
-callback for overlay background press
+handler for backdrop press (only works when `fullscreen` is false)
 
 |   Type   | Default |
 | :------: | :-----: |
 | function |  none   |
-
----
-
-### `width`
-
-Width of the overlay
-
-|       Type       |      Default      |
-| :--------------: | :---------------: |
-| string or number | window width - 80 |
-
----
-
-### `windowBackgroundColor`
-
-Background color for the overlay background
-
-|  Type  |      Default      |
-| :----: | :---------------: |
-| string | rgba(0, 0, 0, .5) |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1161,49 +1161,14 @@ export interface OverlayProps extends ModalProps {
   isVisible: boolean;
 
   /**
-   * Style for the overlay container
+   * Style for the backdrop
    */
-  containerStyle?: StyleProp<ViewStyle>;
+  backdropStyle?: StyleProp<ViewStyle>;
 
   /**
    * Style of the actual overlay
    */
   overlayStyle?: StyleProp<ViewStyle>;
-
-  /**
-   * Background color of the actual overlay
-   *
-   * @default white
-   */
-  windowBackgroundColor?: string;
-
-  /**
-   * Background color for the overlay background
-   *
-   * @default rgba(0, 0, 0, .5)
-   */
-  overlayBackgroundColor?: string;
-
-  /**
-   * Border radius for the overlay
-   *
-   * @default 3
-   */
-  borderRadius?: number;
-
-  /**
-   * Width of the overlay
-   *
-   * @default 'Screen width -80'
-   */
-  width?: number | string;
-
-  /**
-   * Height of the overlay
-   *
-   * @default 'Screen height - 180'
-   */
-  height?: number | string;
 
   /**
    * If to take up full screen width and height

--- a/src/overlay/Overlay.js
+++ b/src/overlay/Overlay.js
@@ -9,87 +9,57 @@ import {
 } from 'react-native';
 
 import { ViewPropTypes, withTheme } from '../config';
-import { ScreenHeight, ScreenWidth } from '../helpers';
 
-const Overlay = props => {
-  const {
-    children,
-    isVisible,
-    containerStyle,
-    overlayStyle,
-    windowBackgroundColor,
-    overlayBackgroundColor,
-    onBackdropPress,
-    borderRadius,
-    width,
-    height,
-    fullScreen,
-    ...rest
-  } = props;
-
-  return (
-    <Modal
-      visible={isVisible}
-      onRequestClose={onBackdropPress}
-      transparent
-      {...rest}
+const Overlay = ({
+  children,
+  backdropStyle,
+  overlayStyle,
+  onBackdropPress,
+  fullScreen,
+  isVisible,
+  ...rest
+}) => (
+  <Modal
+    visible={isVisible}
+    onRequestClose={onBackdropPress}
+    transparent
+    {...rest}
+  >
+    <TouchableWithoutFeedback
+      onPress={onBackdropPress}
+      testID="RNE__Overlay__backdrop"
     >
-      <TouchableWithoutFeedback
-        onPress={onBackdropPress}
-        testID="RNE__Overlay__backdrop"
-      >
-        <View
-          testID="overlayContainer"
-          style={StyleSheet.flatten([
-            styles.backdrop,
-            { backgroundColor: windowBackgroundColor },
-            containerStyle,
-          ])}
-        />
-      </TouchableWithoutFeedback>
+      <View
+        testID="backdrop"
+        style={StyleSheet.flatten([styles.backdrop, backdropStyle])}
+      />
+    </TouchableWithoutFeedback>
 
-      <View style={styles.container} pointerEvents="box-none">
-        <View
-          style={StyleSheet.flatten([
-            styles.overlay,
-            {
-              borderRadius,
-              backgroundColor: overlayBackgroundColor,
-              width,
-              height,
-            },
-            fullScreen && styles.fullscreen,
-            overlayStyle,
-          ])}
-        >
-          {children}
-        </View>
+    <View style={styles.container} pointerEvents="box-none">
+      <View
+        style={StyleSheet.flatten([
+          styles.overlay,
+          fullScreen && styles.fullscreen,
+          overlayStyle,
+        ])}
+      >
+        {children}
       </View>
-    </Modal>
-  );
-};
+    </View>
+  </Modal>
+);
 
 Overlay.propTypes = {
   children: PropTypes.element.isRequired,
   isVisible: PropTypes.bool.isRequired,
-  containerStyle: ViewPropTypes.style,
+  backdropStyle: ViewPropTypes.style,
   overlayStyle: ViewPropTypes.style,
-  windowBackgroundColor: PropTypes.string,
-  overlayBackgroundColor: PropTypes.string,
   onBackdropPress: PropTypes.func,
-  borderRadius: PropTypes.number,
-  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   fullScreen: PropTypes.bool,
 };
 
 Overlay.defaultProps = {
-  borderRadius: 3,
   fullScreen: false,
-  windowBackgroundColor: 'rgba(0, 0, 0, .4)',
-  overlayBackgroundColor: 'white',
-  width: ScreenWidth - 80,
-  height: ScreenHeight - 180,
   onBackdropPress: () => null,
 };
 
@@ -102,6 +72,7 @@ const styles = StyleSheet.create({
     height: '100%',
     justifyContent: 'center',
     alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, .4)',
   },
   container: {
     flex: 1,
@@ -113,7 +84,8 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   overlay: {
-    borderRadius: 5,
+    backgroundColor: 'white',
+    borderRadius: 3,
     padding: 10,
     ...Platform.select({
       android: {

--- a/src/overlay/__tests__/Overlay.js
+++ b/src/overlay/__tests__/Overlay.js
@@ -42,10 +42,29 @@ describe('Overlay', () => {
       .simulate('press');
   });
 
+  it('should click the backdrop and use passed handler', () => {
+    const onBackdropPress = jest.fn();
+
+    const wrapper = shallow(
+      <Overlay isVisible onBackdropPress={onBackdropPress}>
+        <Text>I'm in an Overlay</Text>
+      </Overlay>
+    );
+
+    wrapper
+      .dive()
+      .find({ testID: 'RNE__Overlay__backdrop' })
+      .simulate('press');
+
+    expect(onBackdropPress).toHaveBeenCalled();
+  });
+
   it('should apply values from theme', () => {
     const theme = {
       Overlay: {
-        windowBackgroundColor: 'green',
+        backdropStyle: {
+          backgroundColor: 'green',
+        },
       },
     };
 

--- a/src/overlay/__tests__/__snapshots__/Overlay.js.snap
+++ b/src/overlay/__tests__/__snapshots__/Overlay.js.snap
@@ -8,7 +8,9 @@ exports[`Overlay should apply values from theme 1`] = `
   theme={
     Object {
       "Overlay": Object {
-        "windowBackgroundColor": "green",
+        "backdropStyle": Object {
+          "backgroundColor": "green",
+        },
       },
       "colors": Object {
         "disabled": "hsl(208, 8%, 90%)",
@@ -86,7 +88,6 @@ exports[`Overlay should apply values from theme 1`] = `
         Object {
           "backgroundColor": "white",
           "borderRadius": 3,
-          "height": 1154,
           "padding": 10,
           "shadowColor": "rgba(0, 0, 0, .3)",
           "shadowOffset": Object {
@@ -94,7 +95,6 @@ exports[`Overlay should apply values from theme 1`] = `
             "width": 0,
           },
           "shadowRadius": 4,
-          "width": 670,
         }
       }
     >
@@ -130,7 +130,7 @@ exports[`Overlay should be able to render fullscreen 1`] = `
           "width": "100%",
         }
       }
-      testID="overlayContainer"
+      testID="backdrop"
     />
   </TouchableWithoutFeedback>
   <View
@@ -192,7 +192,7 @@ exports[`Overlay should render without issues 1`] = `
           "width": "100%",
         }
       }
-      testID="overlayContainer"
+      testID="backdrop"
     />
   </TouchableWithoutFeedback>
   <View
@@ -210,7 +210,6 @@ exports[`Overlay should render without issues 1`] = `
         Object {
           "backgroundColor": "white",
           "borderRadius": 3,
-          "height": 1154,
           "padding": 10,
           "shadowColor": "rgba(0, 0, 0, .3)",
           "shadowOffset": Object {
@@ -218,7 +217,6 @@ exports[`Overlay should render without issues 1`] = `
             "width": 0,
           },
           "shadowRadius": 4,
-          "width": 670,
         }
       }
     >


### PR DESCRIPTION
BREAKING CHANGE: Removes containerStyle, windowBackgroundColor, overlayBackgroundColor, borderRadius, width, and height props. Initial width and height of overlay are now `auto` before having set values.

- `containerStyle` is now `backdropStyle`
- `windowBackgroundColor`, can just set backgroundColor on `backdropStyle`
- `overlayBackgroundColor`, can just set backgroundColor on `overlayStyle`
- `borderRadius`, can just set borderRadius on `overlayStyle`
- `width` , `height`, can just set width and height on `overlayStyle`