### PR TITLE
fix(test): Exclude node_modules when running Jest #devcjog25

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "timers": "fake",
     "coverageDirectory": "./coverage/",
     "testPathIgnorePatterns": [
-      "./src/searchbar/__tests__/common.js"
+      "./src/searchbar/__tests__/common.js",
+      "<rootDir>/node_modules"
     ],
     "collectCoverageFrom": [
       "src/**/*.js",


### PR DESCRIPTION
Remove skipped tests from node_modules.

```
  getTooltipCoordinate.js |       90 |    42.11 |      100 |    89.47 |    15,122,123,134 |
--------------------------|----------|----------|----------|----------|-------------------|
Test Suites: 27 passed, 27 total
Tests:       284 passed, 284 total
Snapshots:   196 passed, 196 total
Time:        21.469s
Ran all test suites.
✨  Done in 22.92s.
```

Close #2154