### PR TITLE
chore: Remove redundant syntaxes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ install:
   - yarn global add codecov
   - yarn
 script:
-  - yarn run lint
-  - yarn run test:ci && codecov
+  - yarn lint
+  - yarn test:ci && codecov
 after_success:
   - |
     if [ "$TRAVIS_PULL_REQUEST" == "false" ] && ["$TRAVIS_BRANCH" == "next" ]; then
       git config --global user.name "React Native Elements CI"
       echo -e "machine github.com\n login react-native-elements-ci\n password $GITHUB_TOKEN" >> ~/.netrc
-      cd website && yarn && GIT_USER=react-native-elements-ci yarn run publish-gh-pages
+      cd website && yarn && GIT_USER=react-native-elements-ci yarn publish-gh-pages
     fi


### PR DESCRIPTION
In `yarn`, we don't need the `run`.