### PR TITLE
fix(test): Add coveragePathIgnorePatterns property

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
       "./src/searchbar/__tests__/common.js",
       "<rootDir>/node_modules"
     ],
+    "coveragePathIgnorePatterns": [
+      "./src/searchbar/__tests__/common.js"
+    ],
     "collectCoverageFrom": [
       "src/**/*.js",
       "!src/index.js",


### PR DESCRIPTION
### Problem

Since Jest ignores `searchbar/__tests__/common.js` [#L74](https://github.com/react-native-elements/react-native-elements/blob/64315d6469cc34b67393e8c192d581118ed341c0/package.json#L74) we also need to ignore coverage for it as well.

![image](https://user-images.githubusercontent.com/17120764/67726541-be471780-fa18-11e9-86d9-0f7e325cf7e3.png)

### After the changes

![image](https://user-images.githubusercontent.com/17120764/67726559-ca32d980-fa18-11e9-978f-36a43e4bca3c.png)
