### PR TITLE
test: Increase code coverage for Tooltip component

### DIFF
--- a/src/tooltip/__tests__/Tooltip.android.js
+++ b/src/tooltip/__tests__/Tooltip.android.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Modal, Text, TouchableOpacity } from 'react-native';
+import { create } from 'react-test-renderer';
+
+import { Tooltip } from '../Tooltip';
+
+jest.mock('../../helpers', () => ({
+  isIOS: false,
+}));
+
+describe('Tooltip component (Android)', () => {
+  beforeAll(() => {
+    // Hide console.warn error that shows from using .measure
+    global.console.warn = () => null;
+  });
+
+  it('should trigger toggleTooltip', () => {
+    const Info = () => <Text>Info here</Text>;
+    const component = create(
+      <Tooltip height={100} width={200} popover={<Info />}>
+        <Text>Press me</Text>
+      </Tooltip>
+    );
+
+    const modalComponent = component.root.findByType(Modal);
+
+    component.root.findAllByType(TouchableOpacity)[0].props.onPress();
+    expect(modalComponent.props.visible).toEqual(true);
+
+    component.root.findAllByType(TouchableOpacity)[0].props.onPress();
+    expect(modalComponent.props.visible).toEqual(false);
+  });
+});

--- a/src/tooltip/__tests__/Tooltip.js
+++ b/src/tooltip/__tests__/Tooltip.js
@@ -82,4 +82,24 @@ describe('Tooltip component', () => {
     ).toBe('pink');
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it('should return children for Falsy toggleOnPress', () => {
+    const Info = () => <Text>Info here</Text>;
+    const component = create(
+      <Tooltip
+        height={100}
+        width={200}
+        popover={<Info />}
+        toggleOnPress={false}
+      >
+        <Text>Press me</Text>
+      </Tooltip>
+    );
+
+    component.root.findAllByType(TouchableOpacity)[0].props.onPress();
+    expect(component.root.findByType(Triangle)).toBeTruthy();
+    expect(component.root.findByType(Info)).toBeTruthy();
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
 });

--- a/src/tooltip/__tests__/__snapshots__/Tooltip.js.snap
+++ b/src/tooltip/__tests__/__snapshots__/Tooltip.js.snap
@@ -365,3 +365,109 @@ exports[`Tooltip component should render without issues 1`] = `
   </Modal>
 </View>
 `;
+
+exports[`Tooltip component should return children for Falsy toggleOnPress 1`] = `
+<View
+  collapsable={false}
+>
+  <Text>
+    Press me
+  </Text>
+  <Modal
+    animationType="fade"
+    hardwareAccelerated={false}
+    onDismiss={[Function]}
+    onRequestClose={[Function]}
+    onShow={[Function]}
+    transparent={true}
+    visible={true}
+  >
+    <View
+      accessible={true}
+      isTVSelectable={true}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "backgroundColor": "rgba(250, 250, 250, 0.70)",
+          "flex": 1,
+          "opacity": 1,
+        }
+      }
+    >
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "transparent",
+              "height": 0,
+              "left": 0,
+              "overflow": "visible",
+              "position": "absolute",
+              "top": 0,
+              "width": 0,
+            }
+          }
+        >
+          <Text>
+            Press me
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "left": -7.5,
+              "position": "absolute",
+              "top": -2,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "transparent",
+                "borderBottomColor": "#617080",
+                "borderBottomWidth": 15,
+                "borderLeftColor": "transparent",
+                "borderLeftWidth": 8,
+                "borderRightColor": "transparent",
+                "borderRightWidth": 8,
+                "borderStyle": "solid",
+                "height": 0,
+                "width": 0,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "#617080",
+              "borderRadius": 10,
+              "display": "flex",
+              "flex": 1,
+              "height": 100,
+              "justifyContent": "center",
+              "left": -17.999,
+              "padding": 10,
+              "position": "absolute",
+              "top": 10,
+              "width": 200,
+            }
+          }
+          testID="tooltipPopoverContainer"
+        >
+          <Text>
+            Info here
+          </Text>
+        </View>
+      </View>
+    </View>
+  </Modal>
+</View>
+`;


### PR DESCRIPTION
### Before

```
 tooltip                  |    91.14 |    48.89 |     87.5 |    90.91 |                   |
  Tooltip.js              |    91.43 |    54.17 |    78.57 |    91.43 |         29,45,161 |
  Triangle.js             |      100 |       50 |      100 |      100 |                12 |
  getTooltipCoordinate.js |       90 |    42.11 |      100 |    89.47 |    15,122,123,134 |
```

### After

```
 tooltip                  |     96.2 |    75.56 |    91.67 |     96.1 |                   |
  Tooltip.js              |    97.14 |    79.17 |    85.71 |    97.14 |               161 |
  Triangle.js             |      100 |      100 |      100 |      100 |                   |
  getTooltipCoordinate.js |       95 |    68.42 |      100 |    94.74 |            15,134 |
```