### PR TITLE
test: Increase code coverage for SocialIcon component

### DIFF
--- a/src/social/__tests__/SocialIcon.js
+++ b/src/social/__tests__/SocialIcon.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ActivityIndicator } from 'react-native';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { create } from 'react-test-renderer';
@@ -21,9 +22,51 @@ describe('SocialIcon component', () => {
     expect(component.find('ActivityIndicator').length).toBe(1);
   });
 
+  it('should show loading indicator in small size', () => {
+    const component = create(<SocialIcon loading small="small" />);
+
+    const activityIndicator = component.root.findByType(ActivityIndicator);
+    expect(activityIndicator.props.size).toEqual('small');
+  });
+
+  it('should show loading indicator in white color', () => {
+    const component = create(<SocialIcon loading iconColor={null} />);
+
+    const activityIndicator = component.root.findByType(ActivityIndicator);
+    expect(activityIndicator.props.color).toEqual('white');
+  });
+
   it('should render light social icon', () => {
     const component = shallow(
       <SocialIcon light raised={false} type="medium" />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should have width and height based on iconSize', () => {
+    const component = shallow(
+      <SocialIcon button={false} light={false} raised={false} />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should use style and font from props', () => {
+    const component = shallow(
+      <SocialIcon
+        button
+        light
+        title="title"
+        type="github"
+        fontFamily="arial"
+        fontWeight="bold"
+        style={{ backgroundColor: 'pink' }}
+        iconStyle={{ borderWidth: 1 }}
+        fontStyle={{ justifyContent: 'center' }}
+      />
     );
 
     expect(component.length).toBe(1);
@@ -45,6 +88,14 @@ describe('SocialIcon component', () => {
 
     component.simulate('press');
     expect(onPress).toHaveBeenCalled();
+  });
+
+  it('should NOT have onPress event', () => {
+    const onPress = jest.fn();
+    const component = shallow(<SocialIcon onPress={onPress} disabled />);
+
+    component.simulate('press');
+    expect(onPress).not.toHaveBeenCalled();
   });
 
   it('should apply values from theme', () => {

--- a/src/social/__tests__/__snapshots__/SocialIcon.js.snap
+++ b/src/social/__tests__/__snapshots__/SocialIcon.js.snap
@@ -98,6 +98,40 @@ exports[`SocialIcon component should apply values from theme 1`] = `
 </View>
 `;
 
+exports[`SocialIcon component should have width and height based on iconSize 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": undefined,
+      "borderRadius": 48,
+      "flexDirection": "row",
+      "height": 52,
+      "justifyContent": "center",
+      "margin": 7,
+      "width": 52,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "center",
+      }
+    }
+  >
+    <Icon
+      allowFontScaling={false}
+      color="white"
+      size={24}
+      style={Object {}}
+    />
+  </View>
+</View>
+`;
+
 exports[`SocialIcon component should render light social icon 1`] = `
 <View
   style={
@@ -225,6 +259,66 @@ exports[`SocialIcon component should render without issues 1`] = `
       size={24}
       style={Object {}}
     />
+  </View>
+</View>
+`;
+
+exports[`SocialIcon component should use style and font from props 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "pink",
+      "borderRadius": 30,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "margin": 7,
+      "paddingBottom": 14,
+      "paddingTop": 14,
+      "shadowColor": "rgba(0,0,0, .4)",
+      "shadowOffset": Object {
+        "height": 1,
+        "width": 1,
+      },
+      "shadowOpacity": 1,
+      "shadowRadius": 1,
+    }
+  }
+  underlayColor="white"
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "center",
+      }
+    }
+  >
+    <Icon
+      allowFontScaling={false}
+      color="#000000"
+      name="github"
+      size={24}
+      style={
+        Object {
+          "borderWidth": 1,
+        }
+      }
+    />
+    <Themed.Text
+      style={
+        Object {
+          "color": "#000000",
+          "fontFamily": "arial",
+          "fontWeight": "bold",
+          "justifyContent": "center",
+          "marginLeft": 15,
+        }
+      }
+    >
+      title
+    </Themed.Text>
   </View>
 </View>
 `;


### PR DESCRIPTION
### Before

```
 social                   |      100 |       78 |      100 |      100 |                   |
  SocialIcon.js           |      100 |       78 |      100 |      100 |... 14,115,129,130 |
```

### After

```
 social                   |      100 |      100 |      100 |      100 |                   |
  SocialIcon.js           |      100 |      100 |      100 |      100 |                   |
```