### PR TITLE
feat(Image): Add overflow hidden to containerStyle

### DIFF
--- a/src/avatar/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/avatar/__tests__/__snapshots__/Avatar.js.snap
@@ -653,6 +653,7 @@ exports[`Avatar Component should apply values from theme 1`] = `
       Object {
         "backgroundColor": "transparent",
         "flex": 1,
+        "overflow": "hidden",
         "position": "relative",
       }
     }

--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -100,6 +100,7 @@ const styles = {
   container: {
     backgroundColor: 'transparent',
     position: 'relative',
+    overflow: 'hidden',
   },
   placeholderContainer: {
     ...StyleSheet.absoluteFillObject,

--- a/src/image/__tests__/__snapshots__/Image.js.snap
+++ b/src/image/__tests__/__snapshots__/Image.js.snap
@@ -6,6 +6,7 @@ exports[`Image Component should apply values from theme 1`] = `
   style={
     Object {
       "backgroundColor": "transparent",
+      "overflow": "hidden",
       "position": "relative",
     }
   }
@@ -117,6 +118,7 @@ exports[`Image Component should render on android 1`] = `
   style={
     Object {
       "backgroundColor": "transparent",
+      "overflow": "hidden",
       "position": "relative",
     }
   }
@@ -188,6 +190,7 @@ exports[`Image Component should render on ios 1`] = `
   style={
     Object {
       "backgroundColor": "transparent",
+      "overflow": "hidden",
       "position": "relative",
     }
   }
@@ -259,6 +262,7 @@ exports[`Image Component should render without the transition 1`] = `
   style={
     Object {
       "backgroundColor": "transparent",
+      "overflow": "hidden",
       "position": "relative",
     }
   }

--- a/src/tile/__tests__/__snapshots__/Tile.js.snap
+++ b/src/tile/__tests__/__snapshots__/Tile.js.snap
@@ -93,6 +93,7 @@ exports[`Tile component should apply styles from theme 1`] = `
       Object {
         "backgroundColor": "transparent",
         "flex": 2,
+        "overflow": "hidden",
         "position": "relative",
       }
     }


### PR DESCRIPTION
Adding a borderRadius to the Image component would always require you to
pass overflow: hidden as well. Since this is a common use, we should add
the overflow:hidden by default.

BREAKING CHANGE: Image will no longer overflow the container. If you need this behaviour then set overflow: visible on the containerStyle.