### PR TITLE
allow `marginHorizontal` and `marginVertical`  for ButtonGroup

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -171,10 +171,8 @@ const styles = {
     alignItems: 'center',
   },
   container: {
-    marginLeft: 10,
-    marginRight: 10,
-    marginBottom: 5,
-    marginTop: 5,
+    marginHorizontal: 10,
+    marginVertical: 5,
     borderColor: '#e3e3e3',
     borderWidth: 1,
     flexDirection: 'row',

--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -10,10 +10,8 @@ exports[`ButtonGroup Component Disabled should apply disabled styles 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }
@@ -176,10 +174,8 @@ exports[`ButtonGroup Component Disabled should disable all items 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }
@@ -342,10 +338,8 @@ exports[`ButtonGroup Component Disabled should disable only some items 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }
@@ -507,10 +501,8 @@ exports[`ButtonGroup Component should apply values from theme 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }
@@ -810,10 +802,8 @@ exports[`ButtonGroup Component should have default onPress event 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }
@@ -973,10 +963,8 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }
@@ -1137,10 +1125,8 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }
@@ -1301,10 +1287,8 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }
@@ -1396,10 +1380,8 @@ exports[`ButtonGroup Component should render without inner borders 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }
@@ -1559,10 +1541,8 @@ exports[`ButtonGroup Component should render without issues 1`] = `
       "borderWidth": 1,
       "flexDirection": "row",
       "height": 40,
-      "marginBottom": 5,
-      "marginLeft": 10,
-      "marginRight": 10,
-      "marginTop": 5,
+      "marginHorizontal": 10,
+      "marginVertical": 5,
       "overflow": "hidden",
     }
   }

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -288,10 +288,8 @@ const styles = {
   },
   buttonGroupContainer: {
     flex: 1,
-    marginLeft: 0,
-    marginRight: 0,
-    marginTop: 0,
-    marginBottom: 0,
+    marginHorizontal: 0,
+    marginVertical: 0,
   },
   rightTitle: {
     color: ANDROID_SECONDARY,


### PR DESCRIPTION
RN styles parser allows `marginLeft` and `marginRight` to override `marginHorizontal` but not vice versa.

rel #2170 