### PR TITLE
fix(social): Adding this library did not add react-native-vector-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "opencollective-postinstall": "^2.0.0",
     "prop-types": "^15.7.2",
     "react-native-ratings": "^6.5.0",
-    "react-native-status-bar-height": "^2.2.0"
+    "react-native-status-bar-height": "^2.2.0",
+    "react-native-vector-icons": "^6.0.2"
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "^0.0.5",
@@ -59,7 +60,6 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-native": "0.59.10",
-    "react-native-vector-icons": "^6.0.2",
     "react-test-renderer": "^16.8.6",
     "typescript": "^3.5.2"
   },


### PR DESCRIPTION
Hi 
When the library was actually used in a project, an error occurred in the card component.
When I looked it up, it was registered in devDependencies.
Is this a mistake?

Please check.