### PR TITLE
Have `IconObject` extend `TouchableHighlightProps` so that `HeaderIcon` can support props like `underlayColor`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,7 +43,7 @@ export type IconType =
   | 'antdesign'
   | string;
 
-export interface IconObject {
+export interface IconObject extends TouchableHighlightProps {
   name?: string;
   color?: string;
   size?: number;
@@ -930,7 +930,6 @@ export interface HeaderIcon extends IconObject {
   text?: string;
   color?: string;
   style?: StyleProp<TextStyle>;
-  underlayColor?: string;
 }
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -930,6 +930,7 @@ export interface HeaderIcon extends IconObject {
   text?: string;
   color?: string;
   style?: StyleProp<TextStyle>;
+  underlayColor?: string;
 }
 
 /**


### PR DESCRIPTION
This change will let users specify an `underlayColor` while using an icon in their `Header`. As an example, when faced with a problem like in https://github.com/react-native-elements/react-native-elements/issues/640 we can either use an `Icon` component and pass it the `underlayColor` prop or add the `underlayColor` to the `rightComponent` `HeaderIcon` type. However, the latter is not currently supported by the type definitions.