### PR TITLE
Remove trailing semi-colon

### DIFF
--- a/docs/divider.md
+++ b/docs/divider.md
@@ -11,7 +11,7 @@ distinction between sections of content.
 ```js
 import { Divider } from 'react-native-elements';
 
-<Divider style={{ backgroundColor: 'blue' }} />;
+<Divider style={{ backgroundColor: 'blue' }} />
 ```
 
 ---


### PR DESCRIPTION
I copy/pasted this example and it produced an error because of the trailing semi-colon. It was saying `Invariant Violation: Text strings must be rendered within a <Text> component` because it semi-colon is text. Took me a while to figure out what was going on there.