### PR TITLE
feat#Carousel The most fascinating Carousel component

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "opencollective-postinstall": "^2.0.0",
     "prop-types": "^15.7.2",
     "react-native-ratings": "^6.5.0",
+    "react-native-snap-carousel": "^3.8.4",
     "react-native-status-bar-height": "^2.2.0"
   },
   "devDependencies": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,6 +24,7 @@ import {
   TouchableHighlightProps,
 } from 'react-native';
 import { RatingProps, AirbnbRatingProps } from 'react-native-ratings';
+import { CarouselProps, ParallaxImageProps, PaginationProps } from 'react-native-ratings';
 import { IconButtonProps } from 'react-native-vector-icons/Icon';
 
 /**
@@ -1265,6 +1266,8 @@ export class PricingCard extends React.Component<PricingCardProps, any> {}
  */
 export * from 'react-native-ratings';
 
+export * from 'react-native-snap-carousel';
+
 export type IconNode = boolean | React.ReactElement<{}> | Partial<IconProps>;
 
 export interface SearchBarWrapper {
@@ -2029,6 +2032,9 @@ export interface FullTheme {
   SearchBar: Partial<SearchBarProps>;
   Slider: Partial<SliderProps>;
   SocialIcon: Partial<SocialIconProps>;
+  Carousel: Partial<CarouselProps>;
+  ParallaxImage: Partial<ParallaxImageProps>;
+  Pagination: Partial<PaginationProps>;
   Text: Partial<TextProps>;
   Tile: Partial<TileProps>;
   Tooltip: Partial<TooltipProps>;

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,11 @@ import {
   Rating as BaseRating,
 } from 'react-native-ratings';
 
+import Carousel, {
+  ParallaxImage,
+  Pagination
+} from 'react-native-snap-carousel';
+
 // helpers
 import Text from './text/Text';
 import {
@@ -81,4 +86,7 @@ export {
   withBadge,
   withTheme,
   Image,
+  Carousel,
+  ParallaxImage,
+  Pagination
 };


### PR DESCRIPTION
The carousel component is widely used in microblog, news, and e-commerce apps, But elements don't have any, After comparing the hottest carousel like open source projects, react-native-snap-carousel has the best parallax effect, Hope you guys accept that.
RN-Carousel | Star | License | Npm Week Downloads
-- | -- | -- | --
react-native-swiper | 8.3K | MIT | 39381
react-native-snap-carousel | 6.2K | MIT | 63380
react-native-image-carousel | 189 | MIT | 129
react-native-parallax-swiper | 465 | MIT | 1300

Example:
![](https://camo.githubusercontent.com/7590ec7e6b705a6e8e381397247d576c6db72147/68747470733a2f2f692e696d6775722e636f6d2f653157625a63752e676966)