### PR TITLE
Add prop to disable testID in Image to allow for react-native-fast-image on Android

### DIFF
--- a/docs/divider.md
+++ b/docs/divider.md
@@ -11,7 +11,7 @@ distinction between sections of content.
 ```js
 import { Divider } from 'react-native-elements';
 
-<Divider style={{ backgroundColor: 'blue' }} />;
+<Divider style={{ backgroundColor: 'blue' }} />
 ```
 
 ---

--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -56,7 +56,7 @@ class Image extends React.Component {
         style={StyleSheet.flatten([styles.container, containerStyle])}
       >
         <ImageComponent
-          testID={disableImageTestID ? undefined : "RNE__Image"}
+          testID={disableImageTestID ? undefined : 'RNE__Image'}
           {...attributes}
           onLoad={this.onLoad}
           style={[

--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -40,6 +40,7 @@ class Image extends React.Component {
       style,
       ImageComponent,
       children,
+      disableTestID,
       ...attributes
     } = this.props;
     const hasImage = Boolean(attributes.source);
@@ -50,7 +51,7 @@ class Image extends React.Component {
         style={StyleSheet.flatten([styles.container, containerStyle])}
       >
         <ImageComponent
-          testID="RNE__Image"
+          testID={disableTestID ? undefined : "RNE__Image"}
           {...attributes}
           onLoad={this.onLoad}
           style={[
@@ -112,11 +113,13 @@ Image.propTypes = {
   PlaceholderContent: nodeType,
   containerStyle: ViewPropTypes.style,
   placeholderStyle: ImageNative.propTypes.style,
+  disableTestID: PropTypes.bool,
 };
 
 Image.defaultProps = {
   ImageComponent: ImageNative,
   style: {},
+  disableTestID: false,
 };
 
 export { Image };

--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -120,7 +120,7 @@ Image.propTypes = {
   containerStyle: ViewPropTypes.style,
   placeholderStyle: ImageNative.propTypes.style,
   transition: PropTypes.bool,
-  disableTestID: PropTypes.bool,
+  disableImageTestID: PropTypes.bool,
 };
 
 Image.defaultProps = {


### PR DESCRIPTION
We are using [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) as the `ImageComponent` in our `Avatar`, but there is a [bug](https://github.com/DylanVann/react-native-fast-image/issues/221) in that lib that causes issues on Android when `testID` is set on an `Image`.

Since the `testID` is set by spreading the props, it doesn't allow us to override it with `undefined` or `null`, as it will revert to using the default `RNE__Image`.

I attempted using an empty string but that did not resolve the bug.

This PR adds an optional prop to completely allow disabling the setting of any `testID` on an `Image` component.

Our usage of this:
```js
import FastImage from 'react-native-fast-image'
import { Avatar } from 'react-native-elements';
...
    <Avatar
      // Use FastImage
      ImageComponent={FastImage}
      imageProps={{disableImageTestID: true}}
      {...this.avatarProps}
    />);
```