### PR TITLE
Allow right margin on SearchBar and still have it adjust when cancel slides in

### DIFF
--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -143,8 +143,8 @@ class SearchBar extends Component {
           }}
           inputContainerStyle={StyleSheet.flatten([
             styles.inputContainer,
-            hasFocus && { marginRight: this.state.cancelButtonWidth },
             inputContainerStyle,
+            hasFocus && { marginRight: this.state.cancelButtonWidth },
           ])}
           leftIcon={renderNode(Icon, searchIcon, defaultSearchIcon)}
           leftIconContainerStyle={StyleSheet.flatten([


### PR DESCRIPTION
For reference of how I started with this, and what I tried first, see #2198.

### Scenario

I want the input of the iOS `SearchBar` component to be flush with the edges of the wrapper. I've added a red background to show what I mean. This is default, without messing with any padding or margin. In this case, I want the input of the `SearchBar` to line up with the edges of the light blue cards below.

![PNG image](https://user-images.githubusercontent.com/1460800/69978949-9ffb9c80-152d-11ea-8ed3-80ca186b2f7d.png)

### What I tried

To get the input right to the edges, I tried the following:

```tsx
containerStyle={{
  backgroundColor: 'red',
  paddingBottom: 0, // <- I just wanted to remove the vertical padding for the example
  paddingTop: 0 // <- I just wanted to remove the vertical padding for the example
}}
inputContainerStyle={{
  backgroundColor: color.palette.iOSLightGrey,
  marginLeft: 0 // <- this allows the input to start at the left edge of its container
  marginRight: 0 // <- here is the issue now (see below)
}}
```

This gives me the following:

![PNG image](https://user-images.githubusercontent.com/1460800/70220312-ac0e7680-1746-11ea-8888-e34aa0093b07.png)

With this code, it does indeed remove the left margin so the input starts flush with the cards below and it looks good on the right side as well but by overriding `marginRight` as part of `inputContainerStyle`, it overrides the [styles you set](https://github.com/react-native-elements/react-native-elements/blob/next/src/searchbar/SearchBar-ios.js#L146) to adjust the right margin when the cancel button slides in (due to the order the CSS is applied). That means it ends up looking like this when the cancel button is shown:

![PNG image 2](https://user-images.githubusercontent.com/1460800/70220447-eaa43100-1746-11ea-9048-002b3eeb3714.png)

### Potential solution

Apply the user-supplied `inputContainerStyle` styles _before_ you apply the styles that adjust the margin when the cancel button slides in. For most people, nothing will change, but for the few that want to add their own right margin while still allowing it to slide in nicely with the cancel button, this seems like the way to go. With the change, I'd end up with the following as opposed to what's shown in the image above.

![PNG image 3](https://user-images.githubusercontent.com/1460800/70220824-803fc080-1747-11ea-936a-ce0514a9bf07.png)
