### PR TITLE
Fix keep getting Delete 'CR' [prettier/prettier]

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
when running '`yarn lint`' on Windows, I keep getting Delete 'cr' [prettier/prettier](got error at every line of RNE), It's really annoying because I can't examine other changed files. Until a new attribute added to .prettierrc