### PR TITLE
feat(icon): bigger ripple for Icon inside Header

### DIFF
--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -33,6 +33,7 @@ const Children = ({ style, placement, children }) => (
       ? renderNode(Icon, {
           ...children,
           name: children.icon,
+          innerViewStyle: Platform.OS === 'android' && { height: 64 },
           containerStyle: StyleSheet.flatten([
             { alignItems: ALIGN_STYLE[placement] },
             children.containerStyle,

--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -28,6 +28,7 @@ const Icon = props => {
     disabled,
     disabledStyle,
     onPress,
+    innerViewStyle,
     Component = onPress
       ? Platform.select({
           android: TouchableNativeFeedback,
@@ -98,6 +99,7 @@ const Icon = props => {
               alignItems: 'center',
               justifyContent: 'center',
             },
+            innerViewStyle,
             disabled && styles.disabled,
             disabled && disabledStyle,
           ])}


### PR DESCRIPTION
On a native android app, the pressable icons inside headers have a bigger ripple.
This PR fixes the issue, making the ripple conform to the Material guidelines.
