### PR TITLE
fixes Avatar when rounded is true

### DIFF
--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -138,6 +138,7 @@ const Avatar = ({
           overlayContainerStyle,
         ])}
         source={source}
+        borderRadius={rounded ? width / 2 : undefined}
         {...imageProps}
         style={StyleSheet.flatten([
           styles.avatar,

--- a/src/avatar/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/avatar/__tests__/__snapshots__/Avatar.js.snap
@@ -533,6 +533,7 @@ exports[`Avatar Component renders rounded 1`] = `
 >
   <ForwardRef(Themed.Image)
     ImageComponent={[Function]}
+    borderRadius={17}
     containerStyle={
       Object {
         "borderRadius": 17,


### PR DESCRIPTION
The rounded prop doesn't work in some cases. I've fixed it by injecting a borderRadius prop to the Image component.