### PR TITLE
Add card's clickable image

### DIFF
--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, Platform, Image as ImageNative, StyleSheet } from 'react-native';
+import {
+  View,
+  Platform,
+  Image as ImageNative,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
 
 import normalize from '../helpers/normalizeText';
 import { fonts, TextPropTypes, ViewPropTypes, withTheme } from '../config';
@@ -15,6 +21,7 @@ const Card = props => {
     containerStyle,
     wrapperStyle,
     imageWrapperStyle,
+    onPressImage,
     title,
     titleStyle,
     titleNumberOfLines,
@@ -75,37 +82,38 @@ const Card = props => {
 
         {image && (
           <View style={imageWrapperStyle && imageWrapperStyle}>
-            <Image
-              style={[{ width: null, height: 150 }, imageStyle && imageStyle]}
-              source={image}
-              {...imageProps}
-            >
-              {(featuredTitle || featuredSubtitle) && (
-                <View style={styles.overlayContainer}>
-                  {featuredTitle && (
-                    <Text
-                      style={StyleSheet.flatten([
-                        styles.featuredTitle,
-                        featuredTitleStyle && featuredTitleStyle,
-                      ])}
-                    >
-                      {featuredTitle}
-                    </Text>
-                  )}
-                  {featuredSubtitle && (
-                    <Text
-                      style={StyleSheet.flatten([
-                        styles.featuredSubtitle,
-                        featuredSubtitleStyle && featuredSubtitleStyle,
-                      ])}
-                    >
-                      {featuredSubtitle}
-                    </Text>
-                  )}
-                </View>
-              )}
-            </Image>
-
+            <TouchableOpacity onPress={onPressImage} disabled={!onPressImage}>
+              <Image
+                style={[{ width: null, height: 150 }, imageStyle && imageStyle]}
+                source={image}
+                {...imageProps}
+              >
+                {(featuredTitle || featuredSubtitle) && (
+                  <View style={styles.overlayContainer}>
+                    {featuredTitle && (
+                      <Text
+                        style={StyleSheet.flatten([
+                          styles.featuredTitle,
+                          featuredTitleStyle && featuredTitleStyle,
+                        ])}
+                      >
+                        {featuredTitle}
+                      </Text>
+                    )}
+                    {featuredSubtitle && (
+                      <Text
+                        style={StyleSheet.flatten([
+                          styles.featuredSubtitle,
+                          featuredSubtitleStyle && featuredSubtitleStyle,
+                        ])}
+                      >
+                        {featuredSubtitle}
+                      </Text>
+                    )}
+                  </View>
+                )}
+              </Image>
+            </TouchableOpacity>
             <View
               style={StyleSheet.flatten([
                 { padding: 10 },
@@ -141,6 +149,7 @@ Card.propTypes = {
   image: ImageNative.propTypes.source,
   imageStyle: ViewPropTypes.style,
   imageWrapperStyle: ViewPropTypes.style,
+  onPressImage: PropTypes.func,
   imageProps: PropTypes.object,
   titleNumberOfLines: PropTypes.number,
   theme: PropTypes.object,

--- a/src/card/__tests__/Card.js
+++ b/src/card/__tests__/Card.js
@@ -97,4 +97,71 @@ describe('Card Component', () => {
     ).toBe('Yea b');
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it('should have TouchableOpacity active', () => {
+    const onPressImage = jest.fn();
+    const wrapper = shallow(
+      <Card
+        theme={theme}
+        title="foo title"
+        image={{
+          uri:
+            'https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg',
+        }}
+        onPressImage={onPressImage}
+      />
+    );
+    expect(wrapper.find('TouchableOpacity').prop('disabled')).toBeFalsy();
+  });
+
+  it('should have TouchableOpacity disabled', () => {
+    const wrapper = shallow(
+      <Card
+        theme={theme}
+        title="foo title"
+        image={{
+          uri:
+            'https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg',
+        }}
+      />
+    );
+    expect(wrapper.find('TouchableOpacity').prop('disabled')).toBeTruthy();
+  });
+
+  it('should call onPressImage on TouchableOpacity', () => {
+    const onPressImage = jest.fn();
+
+    const wrapper = shallow(
+      <Card
+        theme={theme}
+        title="foo title"
+        image={{
+          uri:
+            'https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg',
+        }}
+        onPressImage={onPressImage}
+      />
+    );
+
+    wrapper
+      .find('TouchableOpacity')
+      .props()
+      .onPress();
+
+    expect(onPressImage).toHaveBeenCalled();
+  });
+
+  it('should not provide any onPress callback to TouchableOpacity', () => {
+    const wrapper = shallow(
+      <Card
+        theme={theme}
+        title="foo title"
+        image={{
+          uri:
+            'https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg',
+        }}
+      />
+    );
+    expect(wrapper.find('TouchableOpacity').props().onPress).toBeUndefined();
+  });
 });

--- a/src/card/__tests__/__snapshots__/Card.js.snap
+++ b/src/card/__tests__/__snapshots__/Card.js.snap
@@ -146,22 +146,27 @@ exports[`Card Component should have Card title with image 1`] = `
       </Themed.Text>
     </View>
     <View>
-      <ForwardRef(Themed.Image)
-        source={
-          Object {
-            "uri": "https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg",
-          }
-        }
-        style={
-          Array [
+      <TouchableOpacity
+        activeOpacity={0.2}
+        disabled={true}
+      >
+        <ForwardRef(Themed.Image)
+          source={
             Object {
-              "height": 150,
-              "width": null,
-            },
-            undefined,
-          ]
-        }
-      />
+              "uri": "https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg",
+            }
+          }
+          style={
+            Array [
+              Object {
+                "height": 150,
+                "width": null,
+              },
+              undefined,
+            ]
+          }
+        />
+      </TouchableOpacity>
       <View
         style={
           Object {
@@ -280,68 +285,73 @@ exports[`Card Component should have Card with featured title 1`] = `
         }
       }
     >
-      <ForwardRef(Themed.Image)
-        source={
-          Object {
-            "uri": "https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg",
-          }
-        }
-        style={
-          Array [
-            Object {
-              "height": 150,
-              "width": null,
-            },
-            Object {
-              "backgroundColor": "red",
-            },
-          ]
-        }
+      <TouchableOpacity
+        activeOpacity={0.2}
+        disabled={true}
       >
-        <View
-          style={
+        <ForwardRef(Themed.Image)
+          source={
             Object {
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "backgroundColor": "rgba(0, 0, 0, 0.2)",
-              "bottom": 0,
-              "flex": 1,
-              "justifyContent": "center",
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "uri": "https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg",
             }
+          }
+          style={
+            Array [
+              Object {
+                "height": 150,
+                "width": null,
+              },
+              Object {
+                "backgroundColor": "red",
+              },
+            ]
           }
         >
-          <Themed.Text
+          <View
             style={
               Object {
-                "backgroundColor": "red",
-                "color": "white",
-                "fontSize": 22.5,
-                "fontWeight": "800",
-                "marginBottom": 8,
+                "alignItems": "center",
+                "alignSelf": "stretch",
+                "backgroundColor": "rgba(0, 0, 0, 0.2)",
+                "bottom": 0,
+                "flex": 1,
+                "justifyContent": "center",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
           >
-            featured title
-          </Themed.Text>
-          <Themed.Text
-            style={
-              Object {
-                "backgroundColor": "red",
-                "color": "white",
-                "fontSize": 16.25,
-                "fontWeight": "400",
-                "marginBottom": 8,
+            <Themed.Text
+              style={
+                Object {
+                  "backgroundColor": "red",
+                  "color": "white",
+                  "fontSize": 22.5,
+                  "fontWeight": "800",
+                  "marginBottom": 8,
+                }
               }
-            }
-          >
-            featured sub title
-          </Themed.Text>
-        </View>
-      </ForwardRef(Themed.Image)>
+            >
+              featured title
+            </Themed.Text>
+            <Themed.Text
+              style={
+                Object {
+                  "backgroundColor": "red",
+                  "color": "white",
+                  "fontSize": 16.25,
+                  "fontWeight": "400",
+                  "marginBottom": 8,
+                }
+              }
+            >
+              featured sub title
+            </Themed.Text>
+          </View>
+        </ForwardRef(Themed.Image)>
+      </TouchableOpacity>
       <View
         style={
           Object {


### PR DESCRIPTION
This PR is related to #814

First part, before the Expo's "refreshing", presents component without passing _onPressImage_ prop, hence the TouchableOpacity inactive. After passing proper function, TouchableOpacity becomes responsive and reacts to consecutive interactions with defined behavior. 

![TRIM_20200128_214125](https://user-images.githubusercontent.com/37783495/73310682-16aed080-4225-11ea-8b03-a7973c6f03eb.gif)

Usage in basic code example:
```
import React, { useState } from "react";
import { StyleSheet, View } from "react-native";
import { Card, Icon, Button, Text } from "react-native-elements";

export default function App() {
  const [isTextShown, setTextShown] = useState(true);

  const handlePressImage = () => {
    setTextShown(!isTextShown);
  };

  return (
    <View style={styles.container}>
      {isTextShown && <Text h4>HELLO WORLD</Text>}
      <Card
        title="Default title"
        image={require("./assets/big-whale.jpeg")}
        onPressImage={handlePressImage}
      >
        <Text style={{ marginBottom: 10 }}>
          The idea with React Native Elements is more about component structure
          than actual design.
        </Text>
        <Button
          icon={<Icon name="code" color="#ffffff" />}
          buttonStyle={{
            borderRadius: 0,
            marginLeft: 0,
            marginRight: 0,
            marginBottom: 0
          }}
          title="VIEW NOW"
        />
      </Card>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: "#fff",
    alignItems: "center",
    justifyContent: "center"
  }
});
```


