### PR TITLE
meta: Added GitHub sponsor button config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: react-native-elements


### PR DESCRIPTION
Leverage the GitHub sponsor button to make people aware about the various ways in which one can support the development.