### PR TITLE
fix(CheckBox): Allow default checkbox testID to be overwritten

### DIFF
--- a/src/checkbox/CheckBox.js
+++ b/src/checkbox/CheckBox.js
@@ -43,8 +43,8 @@ const CheckBox = props => {
     <Component
       accessibilityRole="checkbox"
       accessibilityStates={accessibilityStates}
-      {...attributes}
       testID="checkbox"
+      {...attributes}
       onLongPress={onLongPress}
       onPress={onPress}
       style={StyleSheet.flatten([


### PR DESCRIPTION
Allows the default `testID` prop value to be overwritten when such prop is provided.