### PR TITLE
fix: add iconType to SocialIcon

### DIFF
--- a/docs/social_icons.md
+++ b/docs/social_icons.md
@@ -72,6 +72,7 @@ import { SocialIcon } from 'react-native-elements'
 - [`iconColor`](#iconcolor)
 - [`iconSize`](#iconsize)
 - [`iconStyle`](#iconstyle)
+- [`iconType`](#icontype)
 - [`light`](#light)
 - [`loading`](#loading)
 - [`onLongPress`](#onlongpress)
@@ -173,6 +174,16 @@ extra styling for icon component (optional)
 |      Type      | Default |
 | :------------: | :-----: |
 | object (style) |  none   |
+
+---
+
+### `iconType`
+
+type of icon set. [Supported sets here](./icon.md#available-icon-sets).
+
+|  Type  |   Default    |
+| :----: | :----------: |
+| string | font-awesome |
 
 ---
 

--- a/src/social/SocialIcon.js
+++ b/src/social/SocialIcon.js
@@ -9,7 +9,7 @@ import {
   Text as NativeText,
 } from 'react-native';
 
-import Icon from 'react-native-vector-icons/FontAwesome';
+import Icon from '../icons/Icon';
 import Text from '../text/Text';
 import fonts from '../config/fonts';
 
@@ -57,6 +57,7 @@ const SocialIcon = props => {
     fontFamily,
     fontStyle,
     fontWeight,
+    iconType,
     iconColor,
     iconSize,
     iconStyle,
@@ -100,10 +101,11 @@ const SocialIcon = props => {
     >
       <View style={styles.wrapper}>
         <Icon
-          style={StyleSheet.flatten([iconStyle && iconStyle])}
+          iconStyle={StyleSheet.flatten([iconStyle && iconStyle])}
           color={light ? colors[type] : iconColor}
           name={type}
           size={iconSize}
+          type={iconType}
         />
         {button && title && (
           <Text
@@ -141,6 +143,7 @@ SocialIcon.propTypes = {
   button: PropTypes.bool,
   onPress: PropTypes.func,
   onLongPress: PropTypes.func,
+  iconType: PropTypes.string,
   iconStyle: ViewPropTypes.style,
   style: ViewPropTypes.style,
   iconColor: PropTypes.string,
@@ -160,6 +163,7 @@ SocialIcon.propTypes = {
 
 SocialIcon.defaultProps = {
   raised: true,
+  iconType: 'font-awesome',
   iconColor: 'white',
   iconSize: 24,
   button: false,

--- a/src/social/__tests__/__snapshots__/SocialIcon.js.snap
+++ b/src/social/__tests__/__snapshots__/SocialIcon.js.snap
@@ -74,26 +74,94 @@ exports[`SocialIcon component should apply values from theme 1`] = `
       }
     }
   >
-    <Text
-      allowFontScaling={false}
+    <View
       style={
-        Array [
-          Object {
-            "color": "white",
-            "fontSize": 24,
-          },
-          Object {},
-          Object {
-            "fontFamily": "FontAwesome",
-            "fontStyle": "normal",
-            "fontWeight": "normal",
-          },
-          Object {},
-        ]
+        Object {
+          "overflow": "hidden",
+        }
       }
     >
-      
-    </Text>
+      <View
+        replaceTheme={[Function]}
+        theme={
+          Object {
+            "SocialIcon": Object {
+              "type": "facebook",
+            },
+            "colors": Object {
+              "disabled": "hsl(208, 8%, 90%)",
+              "divider": "#bcbbc1",
+              "error": "#ff190c",
+              "grey0": "#393e42",
+              "grey1": "#43484d",
+              "grey2": "#5e6977",
+              "grey3": "#86939e",
+              "grey4": "#bdc6cf",
+              "grey5": "#e1e8ee",
+              "greyOutline": "#bbb",
+              "platform": Object {
+                "android": Object {
+                  "error": "#f44336",
+                  "primary": "#2196f3",
+                  "secondary": "#9C27B0",
+                  "success": "#4caf50",
+                  "warning": "#ffeb3b",
+                },
+                "ios": Object {
+                  "error": "#ff3b30",
+                  "primary": "#007aff",
+                  "secondary": "#5856d6",
+                  "success": "#4cd964",
+                  "warning": "#ffcc00",
+                },
+              },
+              "primary": "#2089dc",
+              "searchBg": "#303337",
+              "secondary": "#8F0CE8",
+              "success": "#52c41a",
+              "warning": "#faad14",
+            },
+          }
+        }
+        updateTheme={[Function]}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            brand={false}
+            solid={false}
+            style={
+              Array [
+                Object {
+                  "color": "white",
+                  "fontSize": 24,
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+                Object {
+                  "fontFamily": "FontAwesome",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+            testID="iconIcon"
+          >
+            
+          </Text>
+        </View>
+      </View>
+    </View>
   </View>
 </View>
 `;
@@ -121,12 +189,12 @@ exports[`SocialIcon component should render light social icon 1`] = `
       }
     }
   >
-    <Icon
-      allowFontScaling={false}
+    <Themed.Icon
       color="#02b875"
+      iconStyle={Object {}}
       name="medium"
       size={24}
-      style={Object {}}
+      type="font-awesome"
     />
   </View>
 </View>
@@ -164,12 +232,12 @@ exports[`SocialIcon component should render social icon button 1`] = `
       }
     }
   >
-    <Icon
-      allowFontScaling={false}
+    <Themed.Icon
       color="white"
+      iconStyle={Object {}}
       name="facebook"
       size={24}
-      style={Object {}}
+      type="font-awesome"
     />
     <Themed.Text
       style={
@@ -218,12 +286,12 @@ exports[`SocialIcon component should render without issues 1`] = `
       }
     }
   >
-    <Icon
-      allowFontScaling={false}
+    <Themed.Icon
       color="white"
+      iconStyle={Object {}}
       name="twitter"
       size={24}
-      style={Object {}}
+      type="font-awesome"
     />
   </View>
 </View>


### PR DESCRIPTION
Fixes #872.

Adds a new prop `iconType` to the SocialIcon component.

```
<SocialIcon
    title='Sign In With Facebook'
    button
    type='linkedin'
/>
<SocialIcon
     title='Sign In With Facebook'
     button
     type='linkedin'
     iconType='feather'
/>
```

<img width="316" alt="Screen Shot 2020-04-19 at 1 37 02 PM" src="https://user-images.githubusercontent.com/5239875/79699206-ddde3080-8242-11ea-81e5-68b09685a0a3.png">
