### PR TITLE
feat: image source for avatar accessory

### DIFF
--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -20,8 +20,8 @@ commonly used to represent a user and can contain photos, icons, or even text.
     <figcaption>Icon</figcaption>
   </figure>
   <figure>
-    <img src="/react-native-elements/img/avatar/avatar--edit.jpg" alt="Standard Avatar with edit button" />
-    <figcaption>Standard with edit button</figcaption>
+    <img src="/react-native-elements/img/avatar/avatar--edit.jpg" alt="Standard Avatar with accessory button" />
+    <figcaption>Standard with accessory button</figcaption>
   </figure>
 </div>
 
@@ -45,13 +45,13 @@ import { Avatar } from 'react-native-elements';
 // Avatar with Icon
 <Avatar rounded icon={{ name: 'home' }} />
 
-// Standard Avatar with edit button
+// Standard Avatar with accessory button
 <Avatar
   source={{
     uri:
       'https://s3.amazonaws.com/uifaces/faces/twitter/adhamdannaway/128.jpg',
   }}
-  showEditButton
+  showAccessoryButton
 />
 ```
 
@@ -157,7 +157,7 @@ import { ListItem } from 'react-native-elements';
   leftAvatar={{
     title: name[0],
     source: { uri: avatar_url },
-    showEditButton: true,
+    showAccessoryButton: true,
   }}
   title={name}
   subtitle={role}
@@ -172,18 +172,18 @@ import { ListItem } from 'react-native-elements';
 - [`activeOpacity`](#activeopacity)
 - [`avatarStyle`](#avatarstyle)
 - [`containerStyle`](#containerstyle)
-- [`editButton`](#editbutton)
+- [`accessoryButton`](#accessorybutton)
 - [`icon`](#icon)
 - [`iconStyle`](#iconstyle)
 - [`imageProps`](#imageprops)
-- [`onEditPress`](#oneditpress)
+- [`onAccessoryPress`](#onaccessorypress)
 - [`onLongPress`](#onlongpress)
 - [`onPress`](#onpress)
 - [`overlayContainerStyle`](#overlaycontainerstyle)
 - [`placeholderStyle`](#placeholderstyle)
 - [`rounded`](#rounded)
 - [`size`](#size)
-- [`showEditButton`](#showeditbutton)
+- [`showAccessoryButton`](#showaccessorybutton)
 - [`source`](#source)
 - [`title`](#title)
 - [`titleStyle`](#titlestyle)
@@ -225,13 +225,14 @@ Styling for outer container
 
 ---
 
-### `editButton`
+### `accessoryButton`
 
-Icon props to be user for edit button
+Icon or Image props to be user for accessory button.
+If `source` is supplied to the props, then Image will be used.
 
-|               Type               |                                    Default                                    |
-| :------------------------------: | :---------------------------------------------------------------------------: |
-| {[...Icon props](icon.md#props)} | { name: 'mode-edit', type: 'material', color: '#fff', underlayColor: '#000' } |
+|                                  Type                                  |                                    Default                                    |
+| :--------------------------------------------------------------------: | :---------------------------------------------------------------------------: |
+| {[...Icon props](icon.md#props)} or {[...Image props](image.md#props)} | { name: 'mode-edit', type: 'material', color: '#fff', underlayColor: '#000' } |
 
 ---
 
@@ -266,9 +267,9 @@ Optional properties to pass to the avatar e.g "resizeMode"
 
 ---
 
-### `onEditPress`
+### `onAccessoryPress`
 
-Callback function when pressing on the edit button
+Callback function when pressing on the accessory button
 
 |   Type   | Default |
 | :------: | :-----: |
@@ -336,9 +337,9 @@ Size of the avatar
 
 ---
 
-### `showEditButton`
+### `showAccessoryButton`
 
-Shows an edit button over the avatar (optional)
+Shows an accessory button over the avatar (optional)
 
 |  Type   | Default |
 | :-----: | :-----: |

--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -20,8 +20,8 @@ commonly used to represent a user and can contain photos, icons, or even text.
     <figcaption>Icon</figcaption>
   </figure>
   <figure>
-    <img src="/react-native-elements/img/avatar/avatar--edit.jpg" alt="Standard Avatar with accessory button" />
-    <figcaption>Standard with accessory button</figcaption>
+    <img src="/react-native-elements/img/avatar/avatar--edit.jpg" alt="Standard Avatar with accessory" />
+    <figcaption>Standard with accessory</figcaption>
   </figure>
 </div>
 
@@ -45,13 +45,13 @@ import { Avatar } from 'react-native-elements';
 // Avatar with Icon
 <Avatar rounded icon={{ name: 'home' }} />
 
-// Standard Avatar with accessory button
+// Standard Avatar with accessory
 <Avatar
   source={{
     uri:
       'https://s3.amazonaws.com/uifaces/faces/twitter/adhamdannaway/128.jpg',
   }}
-  showAccessoryButton
+  showAccessory
 />
 ```
 
@@ -157,7 +157,7 @@ import { ListItem } from 'react-native-elements';
   leftAvatar={{
     title: name[0],
     source: { uri: avatar_url },
-    showAccessoryButton: true,
+    showAccessory: true,
   }}
   title={name}
   subtitle={role}
@@ -172,7 +172,7 @@ import { ListItem } from 'react-native-elements';
 - [`activeOpacity`](#activeopacity)
 - [`avatarStyle`](#avatarstyle)
 - [`containerStyle`](#containerstyle)
-- [`accessoryButton`](#accessorybutton)
+- [`accessory`](#accessory)
 - [`icon`](#icon)
 - [`iconStyle`](#iconstyle)
 - [`imageProps`](#imageprops)
@@ -183,7 +183,7 @@ import { ListItem } from 'react-native-elements';
 - [`placeholderStyle`](#placeholderstyle)
 - [`rounded`](#rounded)
 - [`size`](#size)
-- [`showAccessoryButton`](#showaccessorybutton)
+- [`showAccessory`](#showaccessory)
 - [`source`](#source)
 - [`title`](#title)
 - [`titleStyle`](#titlestyle)
@@ -225,9 +225,9 @@ Styling for outer container
 
 ---
 
-### `accessoryButton`
+### `accessory`
 
-Icon or Image props to be user for accessory button.
+Icon or Image props to be user for accessory.
 If `source` is supplied to the props, then Image will be used.
 
 |                                  Type                                  |                                    Default                                    |
@@ -269,7 +269,7 @@ Optional properties to pass to the avatar e.g "resizeMode"
 
 ### `onAccessoryPress`
 
-Callback function when pressing on the accessory button
+Callback function when pressing on the accessory
 
 |   Type   | Default |
 | :------: | :-----: |
@@ -337,9 +337,9 @@ Size of the avatar
 
 ---
 
-### `showAccessoryButton`
+### `showAccessory`
 
-Shows an accessory button over the avatar (optional)
+Shows an accessory over the avatar (optional)
 
 |  Type   | Default |
 | :-----: | :-----: |

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -25,7 +25,7 @@ const avatarSizes = {
   xlarge: 150,
 };
 
-const defaultAccessoryButton = {
+const defaultAccessory = {
   name: 'mode-edit',
   type: 'material',
   color: '#fff',
@@ -46,8 +46,8 @@ const Avatar = ({
   title,
   titleStyle,
   overlayContainerStyle,
-  showAccessoryButton,
-  accessoryButton: passedAccessoryButton,
+  showAccessory,
+  accessory: passedAccessory,
   onAccessoryPress,
   imageProps,
   placeholderStyle,
@@ -61,37 +61,37 @@ const Avatar = ({
   const titleSize = width / 2;
   const iconSize = width / 2;
 
-  const accessoryButton = {
-    ...defaultAccessoryButton,
-    ...passedAccessoryButton,
+  const accessory = {
+    ...defaultAccessory,
+    ...passedAccessory,
   };
-  const accessoryButtonSize = accessoryButton.size || (width + height) / 2 / 3;
+  const accessorySize = accessory.size || (width + height) / 2 / 3;
 
-  const Utils = showAccessoryButton && (
+  const Utils = showAccessory && (
     <TouchableHighlight
       style={StyleSheet.flatten([
-        styles.accessoryButton,
+        styles.accessory,
         {
-          width: accessoryButtonSize,
-          height: accessoryButtonSize,
-          borderRadius: accessoryButtonSize / 2,
+          width: accessorySize,
+          height: accessorySize,
+          borderRadius: accessorySize / 2,
         },
-        accessoryButton.style,
+        accessory.style,
       ])}
-      underlayColor={accessoryButton.underlayColor}
+      underlayColor={accessory.underlayColor}
       onPress={onAccessoryPress}
     >
       <View>
-        {'source' in accessoryButton ? (
+        {'source' in accessory ? (
           <Image
             style={{
-              width: accessoryButtonSize * 0.8,
-              height: accessoryButtonSize * 0.8,
+              width: accessorySize * 0.8,
+              height: accessorySize * 0.8,
             }}
-            {...accessoryButton}
+            {...accessory}
           />
         ) : (
-          <Icon size={accessoryButtonSize * 0.8} {...accessoryButton} />
+          <Icon size={accessorySize * 0.8} {...accessory} />
         )}
       </View>
     </TouchableHighlight>
@@ -178,7 +178,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     textAlign: 'center',
   },
-  accessoryButton: {
+  accessory: {
     position: 'absolute',
     bottom: 0,
     right: 0,
@@ -223,9 +223,9 @@ Avatar.propTypes = {
     PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
     PropTypes.number,
   ]),
-  showAccessoryButton: PropTypes.bool,
+  showAccessory: PropTypes.bool,
   onAccessoryPress: PropTypes.func,
-  accessoryButton: PropTypes.shape({
+  accessory: PropTypes.shape({
     size: PropTypes.number,
     name: PropTypes.string,
     type: PropTypes.string,
@@ -240,10 +240,10 @@ Avatar.propTypes = {
 };
 
 Avatar.defaultProps = {
-  showAccessoryButton: false,
+  showAccessory: false,
   onAccessoryPress: null,
   size: 'small',
-  accessoryButton: defaultAccessoryButton,
+  accessory: defaultAccessory,
   ImageComponent: RNImage,
 };
 

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -85,8 +85,9 @@ const Avatar = ({
         {'source' in accessory ? (
           <Image
             style={{
-              width: accessorySize * 0.8,
-              height: accessorySize * 0.8,
+              width: accessorySize,
+              height: accessorySize,
+              borderRadius: accessorySize / 2,
             }}
             {...accessory}
           />

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -25,7 +25,7 @@ const avatarSizes = {
   xlarge: 150,
 };
 
-const defaultEditButton = {
+const defaultAccessoryButton = {
   name: 'mode-edit',
   type: 'material',
   color: '#fff',
@@ -46,9 +46,9 @@ const Avatar = ({
   title,
   titleStyle,
   overlayContainerStyle,
-  showEditButton,
-  editButton: passedEditButton,
-  onEditPress,
+  showAccessoryButton,
+  accessoryButton: passedAccessoryButton,
+  onAccessoryPress,
   imageProps,
   placeholderStyle,
   renderPlaceholderContent,
@@ -61,28 +61,38 @@ const Avatar = ({
   const titleSize = width / 2;
   const iconSize = width / 2;
 
-  const editButton = {
-    ...defaultEditButton,
-    ...passedEditButton,
+  const accessoryButton = {
+    ...defaultAccessoryButton,
+    ...passedAccessoryButton,
   };
-  const editButtonSize = editButton.size || (width + height) / 2 / 3;
+  const accessoryButtonSize = accessoryButton.size || (width + height) / 2 / 3;
 
-  const Utils = showEditButton && (
+  const Utils = showAccessoryButton && (
     <TouchableHighlight
       style={StyleSheet.flatten([
-        styles.editButton,
+        styles.accessoryButton,
         {
-          width: editButtonSize,
-          height: editButtonSize,
-          borderRadius: editButtonSize / 2,
+          width: accessoryButtonSize,
+          height: accessoryButtonSize,
+          borderRadius: accessoryButtonSize / 2,
         },
-        editButton.style,
+        accessoryButton.style,
       ])}
-      underlayColor={editButton.underlayColor}
-      onPress={onEditPress}
+      underlayColor={accessoryButton.underlayColor}
+      onPress={onAccessoryPress}
     >
       <View>
-        <Icon size={editButtonSize * 0.8} {...editButton} />
+        {'source' in accessoryButton ? (
+          <Image
+            style={{
+              width: accessoryButtonSize * 0.8,
+              height: accessoryButtonSize * 0.8,
+            }}
+            {...accessoryButton}
+          />
+        ) : (
+          <Icon size={accessoryButtonSize * 0.8} {...accessoryButton} />
+        )}
       </View>
     </TouchableHighlight>
   );
@@ -168,7 +178,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     textAlign: 'center',
   },
-  editButton: {
+  accessoryButton: {
     position: 'absolute',
     bottom: 0,
     right: 0,
@@ -213,9 +223,9 @@ Avatar.propTypes = {
     PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
     PropTypes.number,
   ]),
-  showEditButton: PropTypes.bool,
-  onEditPress: PropTypes.func,
-  editButton: PropTypes.shape({
+  showAccessoryButton: PropTypes.bool,
+  onAccessoryPress: PropTypes.func,
+  accessoryButton: PropTypes.shape({
     size: PropTypes.number,
     name: PropTypes.string,
     type: PropTypes.string,
@@ -230,10 +240,10 @@ Avatar.propTypes = {
 };
 
 Avatar.defaultProps = {
-  showEditButton: false,
-  onEditPress: null,
+  showAccessoryButton: false,
+  onAccessoryPress: null,
   size: 'small',
-  editButton: defaultEditButton,
+  accessoryButton: defaultAccessoryButton,
   ImageComponent: RNImage,
 };
 

--- a/src/avatar/__tests__/Avatar.js
+++ b/src/avatar/__tests__/Avatar.js
@@ -144,12 +144,12 @@ describe('Avatar Component', () => {
     });
   });
 
-  describe('Edit button', () => {
+  describe('Accessory button', () => {
     it('ios', () => {
       const component = shallow(
         <Avatar
           source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
-          showEditButton
+          showAccessoryButton
         />
       );
       expect(component.length).toBe(1);
@@ -164,7 +164,23 @@ describe('Avatar Component', () => {
       const component = shallow(
         <Avatar
           source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
-          showEditButton
+          showAccessoryButton
+        />
+      );
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it('image source', () => {
+      const component = shallow(
+        <Avatar
+          source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
+          accessoryButton={{
+            source: {
+              uri: 'https://homepages.cae.wisc.edu/~ece533/images/baboon.png',
+            },
+          }}
+          showAccessoryButton
         />
       );
       expect(component.length).toBe(1);

--- a/src/avatar/__tests__/Avatar.js
+++ b/src/avatar/__tests__/Avatar.js
@@ -144,12 +144,12 @@ describe('Avatar Component', () => {
     });
   });
 
-  describe('Accessory button', () => {
+  describe('Accessory shows', () => {
     it('ios', () => {
       const component = shallow(
         <Avatar
           source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
-          showAccessoryButton
+          showAccessory
         />
       );
       expect(component.length).toBe(1);
@@ -164,7 +164,7 @@ describe('Avatar Component', () => {
       const component = shallow(
         <Avatar
           source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
-          showAccessoryButton
+          showAccessory
         />
       );
       expect(component.length).toBe(1);
@@ -175,12 +175,12 @@ describe('Avatar Component', () => {
       const component = shallow(
         <Avatar
           source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
-          accessoryButton={{
+          accessory={{
             source: {
               uri: 'https://homepages.cae.wisc.edu/~ece533/images/baboon.png',
             },
           }}
-          showAccessoryButton
+          showAccessory
         />
       );
       expect(component.length).toBe(1);

--- a/src/avatar/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/avatar/__tests__/__snapshots__/Avatar.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Avatar Component Edit button android 1`] = `
+exports[`Avatar Component Accessory button android 1`] = `
 <View
   style={
     Object {
@@ -70,7 +70,87 @@ exports[`Avatar Component Edit button android 1`] = `
 </View>
 `;
 
-exports[`Avatar Component Edit button ios 1`] = `
+exports[`Avatar Component Accessory button image source 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "height": 34,
+      "width": 34,
+    }
+  }
+>
+  <ForwardRef(Themed.Image)
+    ImageComponent={[Function]}
+    containerStyle={
+      Object {
+        "flex": 1,
+      }
+    }
+    placeholderStyle={Object {}}
+    source={
+      Object {
+        "uri": "https://i.imgur.com/0y8Ftya.jpg",
+      }
+    }
+    style={
+      Object {
+        "flex": 1,
+        "height": null,
+        "width": null,
+      }
+    }
+  />
+  <TouchableHighlight
+    activeOpacity={0.85}
+    delayPressOut={100}
+    onPress={null}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#aaa",
+        "borderRadius": 5.666666666666667,
+        "bottom": 0,
+        "height": 11.333333333333334,
+        "justifyContent": "center",
+        "position": "absolute",
+        "right": 0,
+        "shadowColor": "#000",
+        "shadowOffset": Object {
+          "height": 1,
+          "width": 1,
+        },
+        "shadowOpacity": 0.5,
+        "shadowRadius": 2,
+        "width": 11.333333333333334,
+      }
+    }
+    underlayColor="#000"
+  >
+    <View>
+      <ForwardRef(Themed.Image)
+        color="#fff"
+        name="mode-edit"
+        source={
+          Object {
+            "uri": "https://homepages.cae.wisc.edu/~ece533/images/baboon.png",
+          }
+        }
+        style={
+          Object {
+            "height": 9.066666666666668,
+            "width": 9.066666666666668,
+          }
+        }
+        type="material"
+        underlayColor="#000"
+      />
+    </View>
+  </TouchableHighlight>
+</View>
+`;
+
+exports[`Avatar Component Accessory button ios 1`] = `
 <View
   style={
     Object {

--- a/src/avatar/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/avatar/__tests__/__snapshots__/Avatar.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Avatar Component Accessory button android 1`] = `
+exports[`Avatar Component Accessory shows android 1`] = `
 <View
   style={
     Object {
@@ -70,7 +70,7 @@ exports[`Avatar Component Accessory button android 1`] = `
 </View>
 `;
 
-exports[`Avatar Component Accessory button image source 1`] = `
+exports[`Avatar Component Accessory shows image source 1`] = `
 <View
   style={
     Object {
@@ -150,7 +150,7 @@ exports[`Avatar Component Accessory button image source 1`] = `
 </View>
 `;
 
-exports[`Avatar Component Accessory button ios 1`] = `
+exports[`Avatar Component Accessory shows ios 1`] = `
 <View
   style={
     Object {

--- a/src/avatar/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/avatar/__tests__/__snapshots__/Avatar.js.snap
@@ -138,8 +138,9 @@ exports[`Avatar Component Accessory shows image source 1`] = `
         }
         style={
           Object {
-            "height": 9.066666666666668,
-            "width": 9.066666666666668,
+            "borderRadius": 5.666666666666667,
+            "height": 11.333333333333334,
+            "width": 11.333333333333334,
           }
         }
         type="material"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -120,7 +120,7 @@ export interface AvatarProps {
   /**
    * Callback function when pressing Edit button
    */
-  onEditPress?(): void;
+  onAccessoryPress?(): void;
 
   /**
    * Callback function when pressing component
@@ -181,14 +181,14 @@ export interface AvatarProps {
    *
    * @default false
    */
-  showEditButton?: boolean;
+  showAccessoryButton?: boolean;
 
   /**
    * Edit button for the avatar
    *
    * @default "{size: null, iconName: 'mode-edit', iconType: 'material', iconColor: '#fff', underlayColor: '#000', style: null}"
    */
-  editButton?: Partial<IconProps>;
+  accessoryButton?: Partial<IconProps>;
 
   /**
    * Style for the placeholder
@@ -880,11 +880,6 @@ export interface InputProps extends TextInputProperties {
    *  props to be passed to the React Native Text component used to display the label (optional)
    */
   labelProps?: TextProps;
-
-  /**
-   *  displays error message
-   */
-  renderErrorMessage?: boolean;
 }
 
 export class Input extends React.Component<InputProps> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -181,14 +181,14 @@ export interface AvatarProps {
    *
    * @default false
    */
-  showAccessoryButton?: boolean;
+  showAccessory?: boolean;
 
   /**
    * Edit button for the avatar
    *
    * @default "{size: null, iconName: 'mode-edit', iconType: 'material', iconColor: '#fff', underlayColor: '#000', style: null}"
    */
-  accessoryButton?: Partial<IconProps>;
+  accessory?: Partial<IconProps>;
 
   /**
    * Style for the placeholder


### PR DESCRIPTION
Fixes: #1952

Changed the `editButton` fields to use `accessoryButton` instead. Added the option to use an Image source as the accessory button.

```js
<Avatar
  large
  rounded
  source={l.image_url ? { uri: l.image_url } : null}
  icon={l.icon}
  title={l.title}
  key={`${chunkIndex}-${i}`}
  accessoryButton={{source: { uri: "https://homepages.cae.wisc.edu/~ece533/images/baboon.png"}}}
  showAccessoryButton
/>
```
![Screen Shot 2020-04-20 at 8 28 53 PM](https://user-images.githubusercontent.com/5239875/79823072-a3aa8700-8347-11ea-81c9-5df27c68db1a.png)
