### PR TITLE
A prop to allow control over button / icon size ratio

### DIFF
--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -23,6 +23,7 @@ const Icon = props => {
     underlayColor,
     reverse,
     raised,
+    buttonStyle,                  // adding a prop for enabled raised or reversed IconComponent wrapper
     containerStyle,
     reverseColor,
     disabled,
@@ -48,10 +49,11 @@ const Icon = props => {
     return raised ? 'white' : 'transparent';
   };
 
-  const buttonStyles = {
+  const buttonStyles = {               
     borderRadius: size + 4,
     height: size * 2 + 4,
     width: size * 2 + 4,
+    ...buttonStyle||{}            // merge provided buttonStyle prop with default
   };
 
   if (Platform.OS === 'android' && !attributes.background) {


### PR DESCRIPTION
I propose to add a 'buttonStyle' prop to control the sizes of 'raised' or 'reversed' icons : ratio btw the icon itself and its circular container.