### PR TITLE
fix empty string checkbox title crash

### DIFF
--- a/src/checkbox/CheckBox.js
+++ b/src/checkbox/CheckBox.js
@@ -63,21 +63,21 @@ const CheckBox = props => {
       >
         {!iconRight && <CheckBoxIcon {...props} checkedColor={checkedColor} />}
 
-        {React.isValidElement(title)
-          ? title
-          : title && (
-              <TextElement
-                testID="checkboxTitle"
-                style={StyleSheet.flatten([
-                  styles.text(theme),
-                  textStyle && textStyle,
-                  fontFamily && { fontFamily },
-                ])}
-                {...titleProps}
-              >
-                {checked ? checkedTitle || title : title}
-              </TextElement>
-            )}
+        {React.isValidElement(title) ? (
+          title
+        ) : (
+          <TextElement
+            testID="checkboxTitle"
+            style={StyleSheet.flatten([
+              styles.text(theme),
+              textStyle && textStyle,
+              fontFamily && { fontFamily },
+            ])}
+            {...titleProps}
+          >
+            {checked ? checkedTitle || title : title}
+          </TextElement>
+        )}
 
         {iconRight && <CheckBoxIcon {...props} checkedColor={checkedColor} />}
       </View>

--- a/src/checkbox/__tests__/__snapshots__/CheckBox.js.snap
+++ b/src/checkbox/__tests__/__snapshots__/CheckBox.js.snap
@@ -137,6 +137,17 @@ exports[`CheckBox Component should allow custom checked Icon 1`] = `
         />
       }
     />
+    <Themed.Text
+      style={
+        Object {
+          "color": "#43484d",
+          "fontWeight": "bold",
+          "marginLeft": 10,
+          "marginRight": 10,
+        }
+      }
+      testID="checkboxTitle"
+    />
   </View>
 </TouchableOpacity>
 `;
@@ -277,6 +288,17 @@ exports[`CheckBox Component should allow custom checked Icon when unchecked 1`] 
           }
         />
       }
+    />
+    <Themed.Text
+      style={
+        Object {
+          "color": "#43484d",
+          "fontWeight": "bold",
+          "marginLeft": 10,
+          "marginRight": 10,
+        }
+      }
+      testID="checkboxTitle"
     />
   </View>
 </TouchableOpacity>
@@ -582,6 +604,17 @@ exports[`CheckBox Component should render with icon and checked 1`] = `
       uncheckedColor="#bfbfbf"
       uncheckedIcon="square-o"
     />
+    <Themed.Text
+      style={
+        Object {
+          "color": "#43484d",
+          "fontWeight": "bold",
+          "marginLeft": 10,
+          "marginRight": 10,
+        }
+      }
+      testID="checkboxTitle"
+    />
   </View>
 </TouchableOpacity>
 `;
@@ -619,6 +652,17 @@ exports[`CheckBox Component should render with icon and iconRight 1`] = `
       }
     }
   >
+    <Themed.Text
+      style={
+        Object {
+          "color": "#43484d",
+          "fontWeight": "bold",
+          "marginLeft": 10,
+          "marginRight": 10,
+        }
+      }
+      testID="checkboxTitle"
+    />
     <CheckBoxIcon
       Component={[Function]}
       center={true}
@@ -754,6 +798,17 @@ exports[`CheckBox Component should render without issues 1`] = `
       titleProps={Object {}}
       uncheckedColor="#bfbfbf"
       uncheckedIcon="square-o"
+    />
+    <Themed.Text
+      style={
+        Object {
+          "color": "#43484d",
+          "fontWeight": "bold",
+          "marginLeft": 10,
+          "marginRight": 10,
+        }
+      }
+      testID="checkboxTitle"
     />
   </View>
 </TouchableOpacity>


### PR DESCRIPTION
Fixes: #2305

When title was empty string it failed the `React.isValidElement` check correctly, but is falsey in the second statement leaving a string outside of any wrapping component.