### PR TITLE
improve PricingCard button props

### DIFF
--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -119,7 +119,7 @@ button information (required)
 
 |                     Type                      | Default |
 | :-------------------------------------------: | :-----: |
-| object {title, icon, buttonStyle, titleStyle} |  none   |
+| {[...Button props](button.md#props)}<br/>**OR**<br/> component|  none   |
 
 ---
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -117,9 +117,9 @@ function to be run when button is pressed
 
 button information (required)
 
-|                     Type                      | Default |
-| :-------------------------------------------: | :-----: |
-| {[...Button props](button.md#props)}<br/>**OR**<br/> component|  none   |
+|                              Type                              | Default |
+| :------------------------------------------------------------: | :-----: |
+| {[...Button props](button.md#props)}<br/>**OR**<br/> component |  none   |
 
 ---
 

--- a/src/pricing/PricingCard.js
+++ b/src/pricing/PricingCard.js
@@ -99,9 +99,15 @@ const PricingButton = props => {
       ])}
       titleStyle={titleStyle}
       onPress={onButtonPress}
-      icon={React.isValidElement(icon) ? icon : (
-        typeof icon === 'string' ? <Icon name={icon} size={15} color="white" /> :
-        <Icon {...icon}/>)}
+      icon={
+        React.isValidElement(icon) ? (
+          icon
+        ) : typeof icon === 'string' ? (
+          <Icon name={icon} size={15} color="white" />
+        ) : (
+          <Icon {...icon} />
+        )
+      }
       {...buttonProps}
     />
   );
@@ -113,9 +119,7 @@ PricingCard.propTypes = {
   title: PropTypes.string,
   price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   info: PropTypes.arrayOf(PropTypes.string),
-  button: PropTypes.oneOfType([
-            PropTypes.element,
-            PropTypes.object,]),
+  button: PropTypes.oneOfType([PropTypes.element, PropTypes.object]),
   color: PropTypes.string,
   onButtonPress: PropTypes.func,
   titleStyle: RNText.propTypes.style,
@@ -197,5 +201,5 @@ const styles = {
   },
 };
 
-export { PricingCard ,PricingButton };
+export { PricingCard, PricingButton };
 export default withTheme(PricingCard, 'PricingCard');

--- a/src/pricing/PricingCard.js
+++ b/src/pricing/PricingCard.js
@@ -65,19 +65,45 @@ const PricingCard = props => {
           </Text>
         ))}
 
-        <Button
-          title={button.title}
-          buttonStyle={StyleSheet.flatten([
-            styles.button,
-            button.buttonStyle,
-            { backgroundColor: color },
-          ])}
-          titleStyle={button.titleStyle}
-          onPress={onButtonPress}
-          icon={<Icon name={button.icon} size={15} color="white" />}
-        />
+        {React.isValidElement(button) ? (
+          button
+        ) : (
+          <PricingButton
+            color={color}
+            onButtonPress={onButtonPress}
+            {...button}
+          />
+        )}
       </View>
     </View>
+  );
+};
+
+const PricingButton = props => {
+  const {
+    title,
+    buttonStyle,
+    color,
+    titleStyle,
+    onButtonPress,
+    icon,
+    ...buttonProps
+  } = props;
+  return (
+    <Button
+      title={title}
+      buttonStyle={StyleSheet.flatten([
+        styles.button,
+        buttonStyle,
+        { backgroundColor: color },
+      ])}
+      titleStyle={titleStyle}
+      onPress={onButtonPress}
+      icon={React.isValidElement(icon) ? icon : (
+        typeof icon === 'string' ? <Icon name={icon} size={15} color="white" /> :
+        <Icon {...icon}/>)}
+      {...buttonProps}
+    />
   );
 };
 
@@ -87,7 +113,9 @@ PricingCard.propTypes = {
   title: PropTypes.string,
   price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   info: PropTypes.arrayOf(PropTypes.string),
-  button: PropTypes.object,
+  button: PropTypes.oneOfType([
+            PropTypes.element,
+            PropTypes.object,]),
   color: PropTypes.string,
   onButtonPress: PropTypes.func,
   titleStyle: RNText.propTypes.style,
@@ -169,5 +197,5 @@ const styles = {
   },
 };
 
-export { PricingCard };
+export { PricingCard ,PricingButton };
 export default withTheme(PricingCard, 'PricingCard');

--- a/src/pricing/__tests__/PricingCard.js
+++ b/src/pricing/__tests__/PricingCard.js
@@ -114,7 +114,7 @@ describe('PricingCard component', () => {
         theme={theme}
         button={{
           title: 'GET STARTED',
-          icon: {name: 'flight-takeoff', size: 30, color: 'red'},
+          icon: { name: 'flight-takeoff', size: 30, color: 'red' },
           disabled: true,
         }}
       />
@@ -129,9 +129,9 @@ describe('PricingButton component', () => {
   it('icon is object', () => {
     const component = shallow(
       <PricingButton
-          title= 'GET STARTED'
-          icon={{name: 'flight-takeoff', size: 30, color: 'red'}}
-          disabled
+        title="GET STARTED"
+        icon={{ name: 'flight-takeoff', size: 30, color: 'red' }}
+        disabled
       />
     );
 
@@ -139,23 +139,20 @@ describe('PricingButton component', () => {
     expect(toJson(component)).toMatchSnapshot();
   });
   it('icon is string', () => {
-      const component = shallow(
-        <PricingButton
-            title= 'GET STARTED'
-            icon='flight-takeoff'
-        />
-      );
-      expect(component.length).toBe(1);
-      expect(toJson(component)).toMatchSnapshot();
-    });
+    const component = shallow(
+      <PricingButton title="GET STARTED" icon="flight-takeoff" />
+    );
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
   it('icon is component', () => {
-        const component = shallow(
-          <PricingButton
-              title= 'GET STARTED'
-              icon={<Icon name='flight-takeoff' size={30} color='red' />}
-          />
-        );
-        expect(component.length).toBe(1);
-        expect(toJson(component)).toMatchSnapshot();
-      });
+    const component = shallow(
+      <PricingButton
+        title="GET STARTED"
+        icon={<Icon name="flight-takeoff" size={30} color="red" />}
+      />
+    );
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
 });

--- a/src/pricing/__tests__/PricingCard.js
+++ b/src/pricing/__tests__/PricingCard.js
@@ -6,7 +6,9 @@ import { create } from 'react-test-renderer';
 import theme from '../../config/theme';
 import { ThemeProvider } from '../../config';
 
-import ThemedPricingCard, { PricingCard } from '../PricingCard';
+import ThemedPricingCard, { PricingCard, PricingButton } from '../PricingCard';
+import Icon from '../../icons/Icon';
+import Button from '../../buttons/Button';
 
 describe('PricingCard component', () => {
   it('should render without issues', () => {
@@ -93,4 +95,67 @@ describe('PricingCard component', () => {
     ).toBe('ALL YOU CAN EAT');
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it('button with custom component', () => {
+    const component = shallow(
+      <PricingCard
+        theme={theme}
+        button={<Button title="GET STARTED" disabled />}
+      />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('button with extended props', () => {
+    const component = shallow(
+      <PricingCard
+        theme={theme}
+        button={{
+          title: 'GET STARTED',
+          icon: {name: 'flight-takeoff', size: 30, color: 'red'},
+          disabled: true,
+        }}
+      />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+});
+
+describe('PricingButton component', () => {
+  it('icon is object', () => {
+    const component = shallow(
+      <PricingButton
+          title= 'GET STARTED'
+          icon={{name: 'flight-takeoff', size: 30, color: 'red'}}
+          disabled
+      />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+  it('icon is string', () => {
+      const component = shallow(
+        <PricingButton
+            title= 'GET STARTED'
+            icon='flight-takeoff'
+        />
+      );
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  it('icon is component', () => {
+        const component = shallow(
+          <PricingButton
+              title= 'GET STARTED'
+              icon={<Icon name='flight-takeoff' size={30} color='red' />}
+          />
+        );
+        expect(component.length).toBe(1);
+        expect(toJson(component)).toMatchSnapshot();
+      });
 });

--- a/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
+++ b/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
@@ -1,5 +1,188 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PricingButton component icon is component 1`] = `
+<ForwardRef(Themed.Button)
+  buttonStyle={
+    Object {
+      "backgroundColor": undefined,
+      "marginBottom": 10,
+      "marginTop": 15,
+    }
+  }
+  icon={
+    <Themed.Icon
+      color="red"
+      name="flight-takeoff"
+      size={30}
+    />
+  }
+  title="GET STARTED"
+/>
+`;
+
+exports[`PricingButton component icon is object 1`] = `
+<ForwardRef(Themed.Button)
+  buttonStyle={
+    Object {
+      "backgroundColor": undefined,
+      "marginBottom": 10,
+      "marginTop": 15,
+    }
+  }
+  disabled={true}
+  icon={
+    <Themed.Icon
+      color="red"
+      name="flight-takeoff"
+      size={30}
+    />
+  }
+  title="GET STARTED"
+/>
+`;
+
+exports[`PricingButton component icon is string 1`] = `
+<ForwardRef(Themed.Button)
+  buttonStyle={
+    Object {
+      "backgroundColor": undefined,
+      "marginBottom": 10,
+      "marginTop": 15,
+    }
+  }
+  icon={
+    <Themed.Icon
+      color="white"
+      name="flight-takeoff"
+      size={15}
+    />
+  }
+  title="GET STARTED"
+/>
+`;
+
+exports[`PricingCard component button with custom component 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "white",
+      "borderColor": "#e1e8ee",
+      "borderWidth": 1,
+      "margin": 15,
+      "marginBottom": 15,
+      "padding": 15,
+      "shadowColor": "rgba(0,0,0, .2)",
+      "shadowOffset": Object {
+        "height": 1,
+        "width": 0,
+      },
+      "shadowOpacity": 0.5,
+      "shadowRadius": 0.5,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+    <Themed.Text
+      style={
+        Object {
+          "color": "#2089dc",
+          "fontSize": 37.5,
+          "fontWeight": "800",
+          "textAlign": "center",
+        }
+      }
+      testID="pricingCardTitle"
+    />
+    <Themed.Text
+      style={
+        Object {
+          "fontSize": 50,
+          "fontWeight": "700",
+          "marginBottom": 10,
+          "marginTop": 10,
+          "textAlign": "center",
+        }
+      }
+    />
+    <ForwardRef(Themed.Button)
+      disabled={true}
+      title="GET STARTED"
+    />
+  </View>
+</View>
+`;
+
+exports[`PricingCard component button with extended props 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "white",
+      "borderColor": "#e1e8ee",
+      "borderWidth": 1,
+      "margin": 15,
+      "marginBottom": 15,
+      "padding": 15,
+      "shadowColor": "rgba(0,0,0, .2)",
+      "shadowOffset": Object {
+        "height": 1,
+        "width": 0,
+      },
+      "shadowOpacity": 0.5,
+      "shadowRadius": 0.5,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+    <Themed.Text
+      style={
+        Object {
+          "color": "#2089dc",
+          "fontSize": 37.5,
+          "fontWeight": "800",
+          "textAlign": "center",
+        }
+      }
+      testID="pricingCardTitle"
+    />
+    <Themed.Text
+      style={
+        Object {
+          "fontSize": 50,
+          "fontWeight": "700",
+          "marginBottom": 10,
+          "marginTop": 10,
+          "textAlign": "center",
+        }
+      }
+    />
+    <PricingButton
+      color="#2089dc"
+      disabled={true}
+      icon={
+        Object {
+          "color": "red",
+          "name": "flight-takeoff",
+          "size": 30,
+        }
+      }
+      title="GET STARTED"
+    />
+  </View>
+</View>
+`;
+
 exports[`PricingCard component should apply values from theme 1`] = `
 <View
   replaceTheme={[Function]}
@@ -534,21 +717,9 @@ exports[`PricingCard component should render titleStyle 1`] = `
     >
       All Core Features
     </Themed.Text>
-    <ForwardRef(Themed.Button)
-      buttonStyle={
-        Object {
-          "backgroundColor": "#2089dc",
-          "marginBottom": 10,
-          "marginTop": 15,
-        }
-      }
-      icon={
-        <Themed.Icon
-          color="white"
-          name="flight-takeoff"
-          size={15}
-        />
-      }
+    <PricingButton
+      color="#2089dc"
+      icon="flight-takeoff"
       title="GET STARTED"
       titleStyle={
         Object {
@@ -660,21 +831,9 @@ exports[`PricingCard component should render with props 1`] = `
     >
       All Core Features
     </Themed.Text>
-    <ForwardRef(Themed.Button)
-      buttonStyle={
-        Object {
-          "backgroundColor": "#2089dc",
-          "marginBottom": 10,
-          "marginTop": 15,
-        }
-      }
-      icon={
-        <Themed.Icon
-          color="white"
-          name="flight-takeoff"
-          size={15}
-        />
-      }
+    <PricingButton
+      color="#2089dc"
+      icon="flight-takeoff"
       title="GET STARTED"
     />
   </View>
@@ -730,21 +889,9 @@ exports[`PricingCard component should render without info 1`] = `
         }
       }
     />
-    <ForwardRef(Themed.Button)
-      buttonStyle={
-        Object {
-          "backgroundColor": "#2089dc",
-          "marginBottom": 10,
-          "marginTop": 15,
-        }
-      }
-      icon={
-        <Themed.Icon
-          color="white"
-          name="flight-takeoff"
-          size={15}
-        />
-      }
+    <PricingButton
+      color="#2089dc"
+      icon="flight-takeoff"
       title="GET STARTED"
     />
   </View>
@@ -842,21 +989,9 @@ exports[`PricingCard component should render without issues 1`] = `
     >
       All Core Features
     </Themed.Text>
-    <ForwardRef(Themed.Button)
-      buttonStyle={
-        Object {
-          "backgroundColor": "#2089dc",
-          "marginBottom": 10,
-          "marginTop": 15,
-        }
-      }
-      icon={
-        <Themed.Icon
-          color="white"
-          name="flight-takeoff"
-          size={15}
-        />
-      }
+    <PricingButton
+      color="#2089dc"
+      icon="flight-takeoff"
       title="GET STARTED"
     />
   </View>


### PR DESCRIPTION
Fixes: #2290

Changed pricing button so that it can accept all Button props. I also discovered that it would be possible for a developer to make a light themed button with a dark icon. So I improved the `button.icon` prop so that it can accept a string (and maintains old format), an object of Icon props, or a custom Icon.

Looking forward I think we could potentially deprecate the `onButtonPress` prop since it can be passed directly through button props instead.