### PR TITLE
Setting 'useNativeDriver' now required for Animated.timing(...) funct…

### DIFF
--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -54,6 +54,7 @@ class Input extends React.Component {
       duration: 375,
       toValue: 3,
       ease: Easing.bounce,
+      useNativeDriver: true,
     }).start();
   };
 


### PR DESCRIPTION
…ion call with RN 0.62.x, see: https://github.com/facebook/react-native/commit/5876052615f4858ed5fc32fa3da9b64695974238.

Did a search for all instances of Animated.timing(...), and only found one instance that was not setting the useNativeDriver property: the Input shake method. Added the useNativeDriver property and set it to true. Tested on iPhone 11 (iOS 13.3) simulator and Android Pixel 3 API 29 emulator and both passed. Since the only other instance of the Animated.timing(...) in RNE was the Image onLoad method and it had useNativeDriver set to false on Android and true on iOS, so I also tested useNativeDriver set to false for Android, but the shake animation no longer worked, so I reverted back to true for both Android and iOS.