### PR TITLE
Fix: Object getting created with key `0`

### DIFF
--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -76,7 +76,10 @@ const Card = props => {
         {image && (
           <View style={imageWrapperStyle && imageWrapperStyle}>
             <Image
-              style={[{ width: null, height: 150 }, imageStyle && imageStyle]}
+              style={StyleSheet.flatten([
+                { width: null, height: 150 },
+                imageStyle && imageStyle,
+              ])}
               source={image}
               {...imageProps}
             >

--- a/src/card/__tests__/__snapshots__/Card.js.snap
+++ b/src/card/__tests__/__snapshots__/Card.js.snap
@@ -153,13 +153,10 @@ exports[`Card Component should have Card title with image 1`] = `
           }
         }
         style={
-          Array [
-            Object {
-              "height": 150,
-              "width": null,
-            },
-            undefined,
-          ]
+          Object {
+            "height": 150,
+            "width": null,
+          }
         }
       />
       <View
@@ -287,15 +284,11 @@ exports[`Card Component should have Card with featured title 1`] = `
           }
         }
         style={
-          Array [
-            Object {
-              "height": 150,
-              "width": null,
-            },
-            Object {
-              "backgroundColor": "red",
-            },
-          ]
+          Object {
+            "backgroundColor": "red",
+            "height": 150,
+            "width": null,
+          }
         }
       >
         <View


### PR DESCRIPTION
Fixes #2336, As StyleSheet.flatten was not used array was getting created instead of object