### PR TITLE
fix: remove React.PropTypes since deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hoist-non-react-statics": "^3.1.0",
     "opencollective-postinstall": "^2.0.0",
     "prop-types": "^15.7.2",
-    "react-native-ratings": "^6.5.0",
+    "react-native-ratings": "^7.2.0",
     "react-native-status-bar-height": "^2.2.0"
   },
   "devDependencies": {

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -211,7 +211,7 @@ Avatar.propTypes = {
   onPress: PropTypes.func,
   onLongPress: PropTypes.func,
   containerStyle: PropTypes.object,
-  source: PropTypes.object,
+  source: PropTypes.node,
   avatarStyle: PropTypes.object,
   rounded: PropTypes.bool,
   title: PropTypes.string,

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -12,7 +12,7 @@ import {
   TouchableWithoutFeedback,
 } from 'react-native';
 
-import { withTheme, ViewPropTypes } from '../config';
+import { withTheme } from '../config';
 import { renderNode, nodeType } from '../helpers';
 
 import Icon from '../icons/Icon';
@@ -210,16 +210,16 @@ Avatar.propTypes = {
   ]),
   onPress: PropTypes.func,
   onLongPress: PropTypes.func,
-  containerStyle: ViewPropTypes.style,
-  source: RNImage.propTypes.source,
-  avatarStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.object,
+  source: PropTypes.object,
+  avatarStyle: PropTypes.object,
   rounded: PropTypes.bool,
   title: PropTypes.string,
-  titleStyle: Text.propTypes.style,
-  overlayContainerStyle: ViewPropTypes.style,
+  titleStyle: PropTypes.object,
+  overlayContainerStyle: PropTypes.object,
   activeOpacity: PropTypes.number,
   icon: PropTypes.object,
-  iconStyle: Text.propTypes.style,
+  iconStyle: PropTypes.object,
   size: PropTypes.oneOfType([
     PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
     PropTypes.number,
@@ -232,9 +232,9 @@ Avatar.propTypes = {
     type: PropTypes.string,
     color: PropTypes.string,
     underlayColor: PropTypes.string,
-    style: ViewPropTypes.style,
+    style: PropTypes.object,
   }),
-  placeholderStyle: ViewPropTypes.style,
+  placeholderStyle: PropTypes.object,
   renderPlaceholderContent: nodeType,
   imageProps: PropTypes.object,
   ImageComponent: PropTypes.elementType,

--- a/src/badge/Badge.js
+++ b/src/badge/Badge.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 
-import { ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 import { renderNode } from '../helpers';
 
 const Badge = props => {
@@ -40,9 +40,9 @@ const Badge = props => {
 };
 
 Badge.propTypes = {
-  containerStyle: ViewPropTypes.style,
-  badgeStyle: ViewPropTypes.style,
-  textStyle: Text.propTypes.style,
+  containerStyle: PropTypes.object,
+  badgeStyle: PropTypes.object,
+  textStyle: PropTypes.object,
   value: PropTypes.node,
   onPress: PropTypes.func,
   Component: PropTypes.elementType,

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import Color from 'color';
 
-import { withTheme, ViewPropTypes } from '../config';
+import { withTheme } from '../config';
 import { renderNode, nodeType, conditionalStyle, color } from '../helpers';
 import Icon from '../icons/Icon';
 
@@ -168,24 +168,24 @@ class Button extends Component {
 
 Button.propTypes = {
   title: PropTypes.string,
-  titleStyle: Text.propTypes.style,
+  titleStyle: PropTypes.object,
   titleProps: PropTypes.object,
-  buttonStyle: ViewPropTypes.style,
+  buttonStyle: PropTypes.object,
   type: PropTypes.oneOf(['solid', 'clear', 'outline']),
   loading: PropTypes.bool,
-  loadingStyle: ViewPropTypes.style,
+  loadingStyle: PropTypes.object,
   loadingProps: PropTypes.object,
   onPress: PropTypes.func,
-  containerStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.object,
   icon: nodeType,
-  iconContainerStyle: ViewPropTypes.style,
+  iconContainerStyle: PropTypes.object,
   iconRight: PropTypes.bool,
   linearGradientProps: PropTypes.object,
   TouchableComponent: PropTypes.elementType,
   ViewComponent: PropTypes.elementType,
   disabled: PropTypes.bool,
-  disabledStyle: ViewPropTypes.style,
-  disabledTitleStyle: Text.propTypes.style,
+  disabledStyle: PropTypes.object,
+  disabledTitleStyle: PropTypes.object,
   raised: PropTypes.bool,
   theme: PropTypes.object,
 };

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -2,14 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   View,
-  Text as NativeText,
   TouchableNativeFeedback,
   TouchableOpacity,
   Platform,
   StyleSheet,
 } from 'react-native';
 
-import { ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 import { normalizeText, color } from '../helpers';
 
 import Text from '../text/Text';
@@ -207,10 +206,10 @@ ButtonGroup.propTypes = {
   Component: PropTypes.elementType,
   onPress: PropTypes.func,
   buttons: PropTypes.array,
-  containerStyle: ViewPropTypes.style,
-  textStyle: NativeText.propTypes.style,
-  selectedTextStyle: NativeText.propTypes.style,
-  selectedButtonStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.object,
+  textStyle: PropTypes.object,
+  selectedTextStyle: PropTypes.object,
+  selectedButtonStyle: PropTypes.object,
   underlayColor: PropTypes.string,
   selectedIndex: PropTypes.number,
   selectedIndexes: PropTypes.arrayOf(PropTypes.number),
@@ -222,17 +221,17 @@ ButtonGroup.propTypes = {
     color: PropTypes.string,
     width: PropTypes.number,
   }),
-  buttonStyle: ViewPropTypes.style,
+  buttonStyle: PropTypes.object,
   selectMultiple: PropTypes.bool,
   theme: PropTypes.object,
   disabled: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.arrayOf(PropTypes.number),
   ]),
-  disabledStyle: ViewPropTypes.style,
-  disabledTextStyle: NativeText.propTypes.style,
-  disabledSelectedStyle: ViewPropTypes.style,
-  disabledSelectedTextStyle: NativeText.propTypes.style,
+  disabledStyle: PropTypes.object,
+  disabledTextStyle: PropTypes.object,
+  disabledSelectedStyle: PropTypes.object,
+  disabledSelectedTextStyle: PropTypes.object,
   vertical: PropTypes.bool,
 };
 

--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, Platform, Image as ImageNative, StyleSheet } from 'react-native';
+import { View, Platform, StyleSheet } from 'react-native';
 
 import normalize from '../helpers/normalizeText';
-import { fonts, TextPropTypes, ViewPropTypes, withTheme } from '../config';
+import { fonts, withTheme } from '../config';
 
 import Text from '../text/Text';
 import Divider from '../divider/Divider';
@@ -128,19 +128,19 @@ Card.propTypes = {
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
   ]),
-  containerStyle: ViewPropTypes.style,
-  wrapperStyle: ViewPropTypes.style,
-  overlayStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.object,
+  wrapperStyle: PropTypes.object,
+  overlayStyle: PropTypes.object,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  titleStyle: TextPropTypes.style,
+  titleStyle: PropTypes.object,
   featuredTitle: PropTypes.string,
-  featuredTitleStyle: TextPropTypes.style,
+  featuredTitleStyle: PropTypes.object,
   featuredSubtitle: PropTypes.string,
-  featuredSubtitleStyle: TextPropTypes.style,
-  dividerStyle: ViewPropTypes.style,
-  image: ImageNative.propTypes.source,
-  imageStyle: ViewPropTypes.style,
-  imageWrapperStyle: ViewPropTypes.style,
+  featuredSubtitleStyle: PropTypes.object,
+  dividerStyle: PropTypes.object,
+  image: PropTypes.object,
+  imageStyle: PropTypes.object,
+  imageWrapperStyle: PropTypes.object,
   imageProps: PropTypes.object,
   titleNumberOfLines: PropTypes.number,
   theme: PropTypes.object,

--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -138,7 +138,7 @@ Card.propTypes = {
   featuredSubtitle: PropTypes.string,
   featuredSubtitleStyle: PropTypes.object,
   dividerStyle: PropTypes.object,
-  image: PropTypes.object,
+  image: PropTypes.node,
   imageStyle: PropTypes.object,
   imageWrapperStyle: PropTypes.object,
   imageProps: PropTypes.object,

--- a/src/checkbox/CheckBox.js
+++ b/src/checkbox/CheckBox.js
@@ -1,16 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  StyleSheet,
-  TouchableOpacity,
-  View,
-  Platform,
-  Text as NativeText,
-} from 'react-native';
+import { StyleSheet, TouchableOpacity, View, Platform } from 'react-native';
 
 import TextElement from '../text/Text';
 import CheckBoxIcon from './CheckBoxIcon';
-import { fonts, ViewPropTypes, withTheme } from '../config';
+import { fonts, withTheme } from '../config';
 
 const CheckBox = props => {
   const { theme, ...rest } = props;
@@ -91,9 +85,9 @@ CheckBox.propTypes = {
   titleProps: PropTypes.object,
   center: PropTypes.bool,
   right: PropTypes.bool,
-  containerStyle: ViewPropTypes.style,
-  wrapperStyle: ViewPropTypes.style,
-  textStyle: NativeText.propTypes.style,
+  containerStyle: PropTypes.object,
+  wrapperStyle: PropTypes.object,
+  textStyle: PropTypes.object,
   onPress: PropTypes.func,
   onLongPress: PropTypes.func,
   checkedTitle: PropTypes.string,

--- a/src/config/ViewPropTypes.js
+++ b/src/config/ViewPropTypes.js
@@ -1,5 +1,0 @@
-import { View, ViewPropTypes as RNViewPropTypes } from 'react-native';
-
-const ViewPropTypes = RNViewPropTypes || View.propTypes;
-
-export default ViewPropTypes;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,21 +1,15 @@
-import { Text } from 'react-native';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 import BackgroundImage from './BackgroundImage';
 import colors from './colors';
-import ViewPropTypes from './ViewPropTypes';
 import fonts from './fonts';
 import ThemeProvider, { ThemeConsumer, ThemeContext } from './ThemeProvider';
 import withTheme from './withTheme';
-
-const TextPropTypes = Text.propTypes;
 
 export {
   BackgroundImage,
   colors,
   getStatusBarHeight,
-  ViewPropTypes,
-  TextPropTypes,
   fonts,
   ThemeProvider,
   ThemeConsumer,

--- a/src/divider/Divider.js
+++ b/src/divider/Divider.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet } from 'react-native';
 
-import { ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 
 const Divider = ({ style, theme, ...rest }) => (
   <View
@@ -12,7 +12,7 @@ const Divider = ({ style, theme, ...rest }) => (
 );
 
 Divider.propTypes = {
-  style: ViewPropTypes.style,
+  style: PropTypes.object,
   theme: PropTypes.object,
 };
 

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -146,7 +146,7 @@ Header.propTypes = {
   centerContainerStyle: PropTypes.object,
   rightContainerStyle: PropTypes.object,
   backgroundColor: PropTypes.string,
-  backgroundImage: PropTypes.object,
+  backgroundImage: PropTypes.node,
   backgroundImageStyle: PropTypes.object,
   containerStyle: PropTypes.object,
   statusBarProps: PropTypes.object,

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -6,10 +6,9 @@ import {
   StyleSheet,
   View,
   ImageBackground,
-  Image,
 } from 'react-native';
 
-import { ViewPropTypes, getStatusBarHeight, withTheme } from '../config';
+import { getStatusBarHeight, withTheme } from '../config';
 import { renderNode, nodeType } from '../helpers';
 
 import Text from '../text/Text';
@@ -44,7 +43,7 @@ const Children = ({ style, placement, children }) => (
 
 Children.propTypes = {
   placement: PropTypes.oneOf(['left', 'center', 'right']),
-  style: ViewPropTypes.style,
+  style: PropTypes.object,
   children: PropTypes.oneOfType([nodeType, PropTypes.node]),
 };
 
@@ -143,13 +142,13 @@ Header.propTypes = {
   leftComponent: nodeType,
   centerComponent: nodeType,
   rightComponent: nodeType,
-  leftContainerStyle: ViewPropTypes.style,
-  centerContainerStyle: ViewPropTypes.style,
-  rightContainerStyle: ViewPropTypes.style,
+  leftContainerStyle: PropTypes.object,
+  centerContainerStyle: PropTypes.object,
+  rightContainerStyle: PropTypes.object,
   backgroundColor: PropTypes.string,
-  backgroundImage: Image.propTypes.source,
-  backgroundImageStyle: Image.propTypes.style,
-  containerStyle: ViewPropTypes.style,
+  backgroundImage: PropTypes.object,
+  backgroundImageStyle: PropTypes.object,
+  containerStyle: PropTypes.object,
   statusBarProps: PropTypes.object,
   barStyle: PropTypes.oneOf(['default', 'light-content', 'dark-content']),
   children: PropTypes.oneOfType([

--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -5,13 +5,12 @@ import {
   TouchableHighlight,
   View,
   StyleSheet,
-  Text as NativeText,
   TouchableNativeFeedback,
 } from 'react-native';
 import Color from 'color';
 
 import getIconType from '../helpers/getIconType';
-import { ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 
 const Icon = props => {
   const {
@@ -129,12 +128,12 @@ Icon.propTypes = {
   underlayColor: PropTypes.string,
   reverse: PropTypes.bool,
   raised: PropTypes.bool,
-  containerStyle: ViewPropTypes.style,
-  iconStyle: NativeText.propTypes.style,
+  containerStyle: PropTypes.object,
+  iconStyle: PropTypes.object,
   onPress: PropTypes.func,
   reverseColor: PropTypes.string,
   disabled: PropTypes.bool,
-  disabledStyle: ViewPropTypes.style,
+  disabledStyle: PropTypes.object,
   solid: PropTypes.bool,
   brand: PropTypes.bool,
 };

--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 
 import { nodeType } from '../helpers';
-import { ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 
 class Image extends React.Component {
   state = {
@@ -122,8 +122,8 @@ Image.propTypes = {
   ...ImageNative.propTypes,
   ImageComponent: PropTypes.elementType,
   PlaceholderContent: nodeType,
-  containerStyle: ViewPropTypes.style,
-  placeholderStyle: ImageNative.propTypes.style,
+  containerStyle: PropTypes.object,
+  placeholderStyle: PropTypes.object,
   transition: PropTypes.bool,
 };
 

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 
 import { nodeType, renderNode, patchWebProps } from '../helpers';
-import { fonts, withTheme, ViewPropTypes, TextPropTypes } from '../config';
+import { fonts, withTheme } from '../config';
 
 import Icon from '../icons/Icon';
 
@@ -161,21 +161,21 @@ class Input extends React.Component {
 }
 
 Input.propTypes = {
-  containerStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.object,
   disabled: PropTypes.bool,
-  disabledInputStyle: TextPropTypes.style,
-  inputContainerStyle: ViewPropTypes.style,
+  disabledInputStyle: PropTypes.object,
+  inputContainerStyle: PropTypes.object,
   leftIcon: nodeType,
-  leftIconContainerStyle: ViewPropTypes.style,
+  leftIconContainerStyle: PropTypes.object,
   rightIcon: nodeType,
-  rightIconContainerStyle: ViewPropTypes.style,
-  inputStyle: TextPropTypes.style,
+  rightIconContainerStyle: PropTypes.object,
+  inputStyle: PropTypes.object,
   InputComponent: PropTypes.elementType,
   errorProps: PropTypes.object,
-  errorStyle: TextPropTypes.style,
+  errorStyle: PropTypes.object,
   errorMessage: PropTypes.string,
   label: PropTypes.node,
-  labelStyle: TextPropTypes.style,
+  labelStyle: PropTypes.object,
   labelProps: PropTypes.object,
   theme: PropTypes.object,
   renderErrorMessage: PropTypes.bool,

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 
 import { renderNode, nodeType } from '../helpers';
-import { ViewPropTypes, TextPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 
 import Avatar from '../avatar/Avatar';
 import Badge from '../badge/Badge';
@@ -301,17 +301,17 @@ const styles = {
 };
 
 ListItem.propTypes = {
-  containerStyle: ViewPropTypes.style,
-  contentContainerStyle: ViewPropTypes.style,
-  rightContentContainerStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.object,
+  contentContainerStyle: PropTypes.object,
+  rightContentContainerStyle: PropTypes.object,
   Component: PropTypes.elementType,
   onPress: PropTypes.func,
   onLongPress: PropTypes.func,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  titleStyle: TextPropTypes.style,
+  titleStyle: PropTypes.object,
   titleProps: PropTypes.object,
   subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  subtitleStyle: TextPropTypes.style,
+  subtitleStyle: PropTypes.object,
   subtitleProps: PropTypes.object,
   leftIcon: nodeType,
   leftAvatar: nodeType,
@@ -320,10 +320,10 @@ ListItem.propTypes = {
   rightAvatar: nodeType,
   rightElement: nodeType,
   rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  rightTitleStyle: TextPropTypes.style,
+  rightTitleStyle: PropTypes.object,
   rightTitleProps: PropTypes.object,
   rightSubtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  rightSubtitleStyle: TextPropTypes.style,
+  rightSubtitleStyle: PropTypes.object,
   rightSubtitleProps: PropTypes.object,
   input: PropTypes.object,
   buttonGroup: PropTypes.object,
@@ -333,7 +333,7 @@ ListItem.propTypes = {
   chevron: nodeType,
   checkmark: nodeType,
   disabled: PropTypes.bool,
-  disabledStyle: ViewPropTypes.style,
+  disabledStyle: PropTypes.object,
   topDivider: PropTypes.bool,
   bottomDivider: PropTypes.bool,
   pad: PropTypes.number,

--- a/src/overlay/Overlay.js
+++ b/src/overlay/Overlay.js
@@ -8,7 +8,7 @@ import {
   Modal,
 } from 'react-native';
 
-import { ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 
 const Overlay = ({
   children,
@@ -53,8 +53,8 @@ const Overlay = ({
 Overlay.propTypes = {
   children: PropTypes.element.isRequired,
   isVisible: PropTypes.bool.isRequired,
-  backdropStyle: ViewPropTypes.style,
-  overlayStyle: ViewPropTypes.style,
+  backdropStyle: PropTypes.object,
+  overlayStyle: PropTypes.object,
   onBackdropPress: PropTypes.func,
   fullScreen: PropTypes.bool,
   ModalComponent: PropTypes.elementType,

--- a/src/pricing/PricingCard.js
+++ b/src/pricing/PricingCard.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, Platform, StyleSheet, Text as RNText } from 'react-native';
+import { View, Platform, StyleSheet } from 'react-native';
 
 import { normalizeText } from '../helpers';
-import { fonts, ViewPropTypes, withTheme } from '../config';
+import { fonts, withTheme } from '../config';
 
 import Text from '../text/Text';
 import Button from '../buttons/Button';
@@ -82,17 +82,17 @@ const PricingCard = props => {
 };
 
 PricingCard.propTypes = {
-  containerStyle: ViewPropTypes.style,
-  wrapperStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.object,
+  wrapperStyle: PropTypes.object,
   title: PropTypes.string,
   price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   info: PropTypes.arrayOf(PropTypes.string),
   button: PropTypes.object,
   color: PropTypes.string,
   onButtonPress: PropTypes.func,
-  titleStyle: RNText.propTypes.style,
-  pricingStyle: RNText.propTypes.style,
-  infoStyle: RNText.propTypes.style,
+  titleStyle: PropTypes.object,
+  pricingStyle: PropTypes.object,
+  infoStyle: PropTypes.object,
   theme: PropTypes.object,
 };
 

--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { StyleSheet, View, ActivityIndicator, Text } from 'react-native';
+import { StyleSheet, View, ActivityIndicator } from 'react-native';
 
-import { ViewPropTypes } from '../config';
 import { nodeType, renderNode } from '../helpers';
 
 import Input from '../input/Input';
@@ -159,11 +158,11 @@ SearchBar.propTypes = {
   cancelIcon: nodeType,
   loadingProps: PropTypes.object,
   showLoading: PropTypes.bool,
-  containerStyle: ViewPropTypes.style,
-  leftIconContainerStyle: ViewPropTypes.style,
-  rightIconContainerStyle: ViewPropTypes.style,
-  inputContainerStyle: ViewPropTypes.style,
-  inputStyle: Text.propTypes.style,
+  containerStyle: PropTypes.object,
+  leftIconContainerStyle: PropTypes.object,
+  rightIconContainerStyle: PropTypes.object,
+  inputContainerStyle: PropTypes.object,
+  inputStyle: PropTypes.object,
   onClear: PropTypes.func,
   onCancel: PropTypes.func,
   onFocus: PropTypes.func,

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ActivityIndicator, View, Text, StyleSheet } from 'react-native';
+import { ActivityIndicator, View, StyleSheet } from 'react-native';
 
-import { ViewPropTypes } from '../config';
 import { renderNode, nodeType } from '../helpers';
 
 import Input from '../input/Input';
@@ -150,11 +149,11 @@ SearchBar.propTypes = {
   searchIcon: nodeType,
   loadingProps: PropTypes.object,
   showLoading: PropTypes.bool,
-  containerStyle: ViewPropTypes.style,
-  leftIconContainerStyle: ViewPropTypes.style,
-  rightIconContainerStyle: ViewPropTypes.style,
-  inputContainerStyle: ViewPropTypes.style,
-  inputStyle: Text.propTypes.style,
+  containerStyle: PropTypes.object,
+  leftIconContainerStyle: PropTypes.object,
+  rightIconContainerStyle: PropTypes.object,
+  inputContainerStyle: PropTypes.object,
+  inputStyle: PropTypes.object,
   onClear: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -10,7 +10,6 @@ import {
   Text,
 } from 'react-native';
 
-import ViewPropTypes from '../config/ViewPropTypes';
 import Input from '../input/Input';
 import Icon from '../icons/Icon';
 import { renderNode, nodeType } from '../helpers';
@@ -228,11 +227,11 @@ SearchBar.propTypes = {
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   onChangeText: PropTypes.func,
-  containerStyle: ViewPropTypes.style,
-  leftIconContainerStyle: ViewPropTypes.style,
-  rightIconContainerStyle: ViewPropTypes.style,
-  inputContainerStyle: ViewPropTypes.style,
-  inputStyle: Text.propTypes.style,
+  containerStyle: PropTypes.object,
+  leftIconContainerStyle: PropTypes.object,
+  rightIconContainerStyle: PropTypes.object,
+  inputContainerStyle: PropTypes.object,
+  inputStyle: PropTypes.object,
   placeholderTextColor: PropTypes.string,
   showCancel: PropTypes.bool,
 };

--- a/src/slider/Slider.js
+++ b/src/slider/Slider.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, Animated, Easing, PanResponder } from 'react-native';
 
-import { ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 
 const TRACK_SIZE = 4;
 const THUMB_SIZE = 20;
@@ -538,17 +538,17 @@ Slider.propTypes = {
   /**
    * The style applied to the slider container.
    */
-  style: ViewPropTypes.style,
+  style: PropTypes.object,
 
   /**
    * The style applied to the track.
    */
-  trackStyle: ViewPropTypes.style,
+  trackStyle: PropTypes.object,
 
   /**
    * The style applied to the thumb.
    */
-  thumbStyle: ViewPropTypes.style,
+  thumbStyle: PropTypes.object,
 
   /**
    * Set this to true to visually see the thumb touch rect in green.
@@ -574,7 +574,7 @@ Slider.propTypes = {
    * Used to configure the animation parameters.  These are the same parameters in the Animated library.
    */
   animationConfig: PropTypes.object,
-  containerStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.object,
 };
 
 Slider.defaultProps = {

--- a/src/social/SocialIcon.js
+++ b/src/social/SocialIcon.js
@@ -6,14 +6,13 @@ import {
   Platform,
   TouchableHighlight,
   ActivityIndicator,
-  Text as NativeText,
 } from 'react-native';
 
 import Icon from '../icons/Icon';
 import Text from '../text/Text';
 import fonts from '../config/fonts';
 
-import { ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 
 const colors = {
   'github-alt': '#000000',
@@ -144,20 +143,20 @@ SocialIcon.propTypes = {
   onPress: PropTypes.func,
   onLongPress: PropTypes.func,
   iconType: PropTypes.string,
-  iconStyle: ViewPropTypes.style,
-  style: ViewPropTypes.style,
+  iconStyle: PropTypes.object,
+  style: PropTypes.object,
   iconColor: PropTypes.string,
   underlayColor: PropTypes.string,
   title: PropTypes.string,
   raised: PropTypes.bool,
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
-  activityIndicatorStyle: ViewPropTypes.style,
+  activityIndicatorStyle: PropTypes.object,
   small: PropTypes.string,
   iconSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   light: PropTypes.bool,
   fontWeight: PropTypes.string,
-  fontStyle: NativeText.propTypes.style,
+  fontStyle: PropTypes.object,
   fontFamily: PropTypes.string,
 };
 

--- a/src/text/Text.js
+++ b/src/text/Text.js
@@ -43,15 +43,15 @@ const TextElement = props => {
 };
 
 TextElement.propTypes = {
-  style: Text.propTypes.style,
+  style: PropTypes.object,
   h1: PropTypes.bool,
   h2: PropTypes.bool,
   h3: PropTypes.bool,
   h4: PropTypes.bool,
-  h1Style: Text.propTypes.style,
-  h2Style: Text.propTypes.style,
-  h3Style: Text.propTypes.style,
-  h4Style: Text.propTypes.style,
+  h1Style: PropTypes.object,
+  h2Style: PropTypes.object,
+  h3Style: PropTypes.object,
+  h4Style: PropTypes.object,
   children: PropTypes.node,
 };
 

--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -124,7 +124,7 @@ FeaturedTile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
   caption: PropTypes.node,
-  imageSrc: PropTypes.object,
+  imageSrc: PropTypes.node,
   onPress: PropTypes.func,
   containerStyle: PropTypes.object,
   iconContainerStyle: PropTypes.object,

--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -1,15 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  TouchableOpacity,
-  Text as NativeText,
-  View,
-  Image,
-  StyleSheet,
-  Dimensions,
-} from 'react-native';
+import { TouchableOpacity, View, StyleSheet, Dimensions } from 'react-native';
 
-import { ViewPropTypes, BackgroundImage, withTheme } from '../config';
+import { BackgroundImage, withTheme } from '../config';
 import { renderNode } from '../helpers';
 
 import Text from '../text/Text';
@@ -131,14 +124,14 @@ FeaturedTile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
   caption: PropTypes.node,
-  imageSrc: Image.propTypes.source,
+  imageSrc: PropTypes.object,
   onPress: PropTypes.func,
-  containerStyle: ViewPropTypes.style,
-  iconContainerStyle: ViewPropTypes.style,
-  imageContainerStyle: ViewPropTypes.style,
-  overlayContainerStyle: ViewPropTypes.style,
-  titleStyle: NativeText.propTypes.style,
-  captionStyle: NativeText.propTypes.style,
+  containerStyle: PropTypes.object,
+  iconContainerStyle: PropTypes.object,
+  imageContainerStyle: PropTypes.object,
+  overlayContainerStyle: PropTypes.object,
+  titleStyle: PropTypes.object,
+  captionStyle: PropTypes.object,
   width: PropTypes.number,
   height: PropTypes.number,
   ImageComponent: PropTypes.elementType,

--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -116,7 +116,7 @@ Tile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
   caption: PropTypes.node,
-  imageSrc: PropTypes.object,
+  imageSrc: PropTypes.node,
   onPress: PropTypes.func,
   activeOpacity: PropTypes.number,
   containerStyle: PropTypes.object,

--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -1,14 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  View,
-  StyleSheet,
-  Dimensions,
-  Image as ImageNative,
-  TouchableOpacity,
-} from 'react-native';
+import { View, StyleSheet, Dimensions, TouchableOpacity } from 'react-native';
 
-import { TextPropTypes, ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 
 import Image from '../image/Image';
 import Text from '../text/Text';
@@ -122,20 +116,20 @@ Tile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
   caption: PropTypes.node,
-  imageSrc: ImageNative.propTypes.source,
+  imageSrc: PropTypes.object,
   onPress: PropTypes.func,
   activeOpacity: PropTypes.number,
-  containerStyle: ViewPropTypes.style,
-  imageContainerStyle: ViewPropTypes.style,
-  iconContainerStyle: ViewPropTypes.style,
-  overlayContainerStyle: ViewPropTypes.style,
-  titleStyle: TextPropTypes.style,
-  captionStyle: TextPropTypes.style,
+  containerStyle: PropTypes.object,
+  imageContainerStyle: PropTypes.object,
+  iconContainerStyle: PropTypes.object,
+  overlayContainerStyle: PropTypes.object,
+  titleStyle: PropTypes.object,
+  captionStyle: PropTypes.object,
   width: PropTypes.number,
   height: PropTypes.number,
   featured: PropTypes.bool,
   children: PropTypes.node,
-  contentContainerStyle: ViewPropTypes.style,
+  contentContainerStyle: PropTypes.object,
   titleNumberOfLines: PropTypes.number,
   imageProps: PropTypes.object,
   ImageComponent: PropTypes.elementType,

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TouchableOpacity, Modal, View, StatusBar } from 'react-native';
 
-import { ViewPropTypes, withTheme } from '../config';
+import { withTheme } from '../config';
 import { ScreenWidth, ScreenHeight, isIOS } from '../helpers';
 
 import Triangle from './Triangle';
@@ -217,7 +217,7 @@ Tooltip.propTypes = {
   toggleOnPress: PropTypes.bool,
   height: PropTypes.number,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  containerStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.object,
   pointerColor: PropTypes.string,
   onClose: PropTypes.func,
   onOpen: PropTypes.func,

--- a/src/tooltip/Triangle.js
+++ b/src/tooltip/Triangle.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet } from 'react-native';
 
-import ViewPropTypes from '../config/ViewPropTypes';
-
 const Triangle = ({ style, isDown }) => (
   <View
     style={StyleSheet.flatten([
@@ -15,7 +13,7 @@ const Triangle = ({ style, isDown }) => (
 );
 
 Triangle.propTypes = {
-  style: ViewPropTypes.style,
+  style: PropTypes.object,
   isDown: PropTypes.bool,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6644,10 +6644,10 @@ react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-native-ratings@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-ratings/-/react-native-ratings-6.5.0.tgz#a1606ccba3c5b54eec8e6cfa4765a45cf0e4ab8d"
-  integrity sha512-YMcfQ7UQCmXGEc/WPlukHSHs5yvckTwjq5fTRk1FG8gaO7fZCNygEUGPuw4Dbvvp3IlsCUn0bOQd63RYsb7NDQ==
+react-native-ratings@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-ratings/-/react-native-ratings-7.2.0.tgz#8523e98868470855ec1d2feb112e466e17a1fd9f"
+  integrity sha512-oSrkQ4rnpYjCw+d6MPJQghXfrfb3uQKoTJx1exdk7xqzw4jnv3pyu0PAuxCDJk/rfDSD/sirIAudz+zdGxrBog==
   dependencies:
     lodash "^4.17.4"
     prop-types "^15.5.10"


### PR DESCRIPTION
Fixes: #2257 
Also depends on a fixed version of RN-ratings: https://github.com/Monte9/react-native-ratings/pull/91
@Monte9 