### PR TITLE
add rtl fix for tooltip modal content

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TouchableOpacity, Modal, View, StatusBar } from 'react-native';
+import {
+  TouchableOpacity,
+  Modal,
+  View,
+  StatusBar,
+  I18nManager,
+} from 'react-native';
 
 import { ViewPropTypes, withTheme } from '../config';
 import { ScreenWidth, ScreenHeight, isIOS } from '../helpers';
@@ -69,7 +75,7 @@ class Tooltip extends React.PureComponent {
 
     return {
       position: 'absolute',
-      left: x,
+      [I18nManager.isRTL ? 'right' : 'left']: x,
       top: y,
       width,
       height,
@@ -95,7 +101,7 @@ class Tooltip extends React.PureComponent {
         style={{
           position: 'absolute',
           top: pastMiddleLine ? yOffset - 13 : yOffset + elementHeight - 2,
-          left:
+          [I18nManager.isRTL ? 'right' : 'left']:
             xOffset +
             getElementVisibleWidth(elementWidth, xOffset, ScreenWidth) / 2 -
             7.5,
@@ -124,7 +130,7 @@ class Tooltip extends React.PureComponent {
           style={{
             position: 'absolute',
             top: yOffset,
-            left: xOffset,
+            [I18nManager.isRTL ? 'right' : 'left']: xOffset,
             backgroundColor: highlightColor,
             overflow: 'visible',
             width: elementWidth,


### PR DESCRIPTION
Fixes: #2125 

I tried to find out why RN was not switching RTL 'left' and 'right' automatically as they should be. I think this is most likely a bug in react-native. But alas, it is what it is I suppose. Here is a simplified fix for this issue.