### PR TITLE
fix: Pass event in SearchBar

### DIFF
--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -51,16 +51,16 @@ class SearchBar extends Component {
     this.props.onCancel();
   };
 
-  onFocus = () => {
-    this.props.onFocus();
+  onFocus = event => {
+    this.props.onFocus(event);
     this.setState({
       hasFocus: true,
       isEmpty: this.props.value === '',
     });
   };
 
-  onBlur = () => {
-    this.props.onBlur();
+  onBlur = event => {
+    this.props.onBlur(event);
     this.setState({ hasFocus: false });
   };
 

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -45,13 +45,13 @@ class SearchBar extends React.Component {
     this.props.onClear();
   };
 
-  onFocus = () => {
-    this.props.onFocus();
+  onFocus = event => {
+    this.props.onFocus(event);
     this.setState({ isEmpty: this.props.value === '' });
   };
 
-  onBlur = () => {
-    this.props.onBlur();
+  onBlur = event => {
+    this.props.onBlur(event);
   };
 
   onChangeText = text => {

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -69,8 +69,8 @@ class SearchBar extends Component {
     }, 0);
   };
 
-  onFocus = () => {
-    this.props.onFocus();
+  onFocus = event => {
+    this.props.onFocus(event);
     UIManager.configureNextLayoutAnimation && LayoutAnimation.easeInEaseOut();
 
     this.setState({
@@ -79,8 +79,8 @@ class SearchBar extends Component {
     });
   };
 
-  onBlur = () => {
-    this.props.onBlur();
+  onBlur = event => {
+    this.props.onBlur(event);
     UIManager.configureNextLayoutAnimation && LayoutAnimation.easeInEaseOut();
 
     if (!this.props.showCancel) {


### PR DESCRIPTION
`onFocus` and `onBlur` from react native return `event`, but we don't pass `event` to `this.props.onFocus` and `this.props.onBlur`.

The not passing event causes some problems when I need to get event from `onFocus` and `onBlur`.

Reference:
* onFocus: https://github.com/facebook/react-native/blob/bf0539fb51aa7dd0f9ad2b6587a047379e43fbe4/Libraries/Components/TextInput/TextInput.js#L1033
* onBlur: https://github.com/facebook/react-native/blob/bf0539fb51aa7dd0f9ad2b6587a047379e43fbe4/Libraries/Components/TextInput/TextInput.js#L1040
