### PR TITLE
Fix for slower Android devices calculating height

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -149,7 +149,7 @@ class Tooltip extends React.PureComponent {
 
   componentDidMount() {
     // wait to compute onLayout values.
-    setTimeout(this.getElementPosition, 500);
+    requestAnimationFrame(() => this.getElementPosition);
   }
 
   getElementPosition = () => {

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -149,7 +149,7 @@ class Tooltip extends React.PureComponent {
 
   componentDidMount() {
     // wait to compute onLayout values.
-    requestAnimationFrame(() => this.getElementPosition);
+    requestAnimationFrame(this.getElementPosition);
   }
 
   getElementPosition = () => {


### PR DESCRIPTION
Rather than waiting an arbitrary time (500ms), let's wait for the screen to finish being painted, using requestAnimationFrame() #2237 