### PR TITLE
Stop triggering LayoutAnimation without setting state in SearchBar-ios

### DIFF
--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -80,9 +80,9 @@ class SearchBar extends Component {
 
   onBlur = event => {
     this.props.onBlur(event);
-    UIManager.configureNextLayoutAnimation && LayoutAnimation.easeInEaseOut();
 
     if (!this.props.showCancel) {
+      UIManager.configureNextLayoutAnimation && LayoutAnimation.easeInEaseOut();
       this.setState({
         hasFocus: false,
       });


### PR DESCRIPTION
I discovered a bug when using the iOS SearchBar where if the `showCancel` prop was set to `true`, then my keyboard was mysteriously reappearing and re-dismissing after navigating away from the screen with the search bar focused. After looking into it further, I found the culprit! It looks like when the `showCancel` prop was added to the SearchBar, the `setState` call in `onBlur` to set `hasFocus` to false was put behind a check to only set state when `showCancel` is falsy; however, the LayoutAnimation trigger that is meant to be coupled with the state update was left outside that conditional. This PR puts the LayoutAnimation trigger under the same conditional as setting state so that unexpected animations do not occur. 