### PR TITLE
Add overlayContainerStyle to Card

### DIFF
--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -86,10 +86,12 @@ const Card = (props) => {
               {...imageProps}
             >
               {(featuredTitle || featuredSubtitle) && (
-                <View style={StyleSheet.flatten([
-                  styles.overlayContainer,
-                  overlayContainerStyle && overlayContainerStyle
-                ])}>
+                <View
+                  style={StyleSheet.flatten([
+                    styles.overlayContainer,
+                    overlayContainerStyle && overlayContainerStyle,
+                  ])}
+                >
                   {featuredTitle && (
                     <Text
                       style={StyleSheet.flatten([
@@ -153,7 +155,10 @@ Card.propTypes = {
   imageStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   imageWrapperStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   imageProps: PropTypes.object,
-  overlayContainerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  overlayContainerStyle: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array,
+  ]),
   titleNumberOfLines: PropTypes.number,
   theme: PropTypes.object,
 };

--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -24,6 +24,7 @@ const Card = (props) => {
     featuredSubtitle,
     featuredSubtitleStyle,
     dividerStyle,
+    overlayContainerStyle,
     image,
     imageStyle,
     imageProps,
@@ -85,7 +86,10 @@ const Card = (props) => {
               {...imageProps}
             >
               {(featuredTitle || featuredSubtitle) && (
-                <View style={styles.overlayContainer}>
+                <View style={StyleSheet.flatten([
+                  styles.overlayContainer,
+                  overlayContainerStyle && overlayContainerStyle
+                ])}>
                   {featuredTitle && (
                     <Text
                       style={StyleSheet.flatten([
@@ -149,6 +153,7 @@ Card.propTypes = {
   imageStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   imageWrapperStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   imageProps: PropTypes.object,
+  overlayContainerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   titleNumberOfLines: PropTypes.number,
   theme: PropTypes.object,
 };

--- a/src/card/__tests__/Card.js
+++ b/src/card/__tests__/Card.js
@@ -65,6 +65,7 @@ describe('Card Component', () => {
         featuredSubtitle="featured sub title"
         featuredTitleStyle={{ backgroundColor: 'red' }}
         featuredSubtitleStyle={{ backgroundColor: 'red' }}
+        overlayContainerStyle={{backgroundColor: 'rgba(255,0,0,.2'}}
       />
     );
 

--- a/src/card/__tests__/Card.js
+++ b/src/card/__tests__/Card.js
@@ -65,7 +65,7 @@ describe('Card Component', () => {
         featuredSubtitle="featured sub title"
         featuredTitleStyle={{ backgroundColor: 'red' }}
         featuredSubtitleStyle={{ backgroundColor: 'red' }}
-        overlayContainerStyle={{backgroundColor: 'rgba(255,0,0,.2'}}
+        overlayContainerStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.2)' }}
       />
     );
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -549,7 +549,6 @@ export interface CardProps {
    * style for overlay when using featured title or featured subtitle
    */
   overlayContainerStyle?: StyleProp<ViewStyle>;
-  
 }
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -544,6 +544,12 @@ export interface CardProps {
    * Optional properties to pass to the image if provided e.g "resizeMode"
    */
   imageProps?: Partial<ImageProps>;
+
+  /**
+   * style for overlay when using featured title or featured subtitle
+   */
+  overlayContainerStyle?: StyleProp<ViewStyle>;
+  
 }
 
 /**

--- a/website/versioned_docs/version-1.2.0/card.md
+++ b/website/versioned_docs/version-1.2.0/card.md
@@ -88,6 +88,7 @@ import { Card, ListItem, Button, Icon } from 'react-native-elements'
 - [`imageProps`](#imageprops)
 - [`imageStyle`](#imagestyle)
 - [`imageWrapperStyle`](#imagewrapperstyle)
+- [`overlayContainerStyle`](#overlaycontainerstyle)
 - [`title`](#title)
 - [`titleNumberOfLines`](#titlenumberoflines)
 - [`titleStyle`](#titlestyle)
@@ -194,6 +195,16 @@ specify styling for view surrounding image
 |     Type      | Default |
 | :-----------: | :-----: |
 | object(style) |  none   |
+
+---
+
+### `overlayContainerStyle`
+
+styling for overlay when using featured title or featured subtitle
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
 
 ---
 


### PR DESCRIPTION
Adding a featuredTitle or featuredSubtitle to a Card adds an overlayContainer with opinionated styling, including an rgba(0,0,0,.2) background. There should be a way for the user to override these styles.