### PR TITLE
Fixing RN 0.63 issue where iOS onClose does not fire

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -31,7 +31,7 @@ class Tooltip extends React.PureComponent {
     const { onClose } = this.props;
     this.getElementPosition();
     this.setState((prevState) => {
-      if (prevState.isVisible && !isIOS) {
+      if (prevState.isVisible) {
         onClose && onClose();
       }
 


### PR DESCRIPTION
Removing is iOS check to fix onClose not firing in RN 0.63