### PR TITLE
Fixed an important typo

### DIFF
--- a/website/versioned_docs/version-2.0.4/avatar.md
+++ b/website/versioned_docs/version-2.0.4/avatar.md
@@ -183,7 +183,7 @@ import { ListItem } from 'react-native-elements';
 - [`placeholderStyle`](#placeholderstyle)
 - [`rounded`](#rounded)
 - [`size`](#size)
-- [`showEditButton`](#showeditbutton)
+- [`showAccessory`](#showaccessory)
 - [`source`](#source)
 - [`title`](#title)
 - [`titleStyle`](#titlestyle)
@@ -336,7 +336,7 @@ Size of the avatar
 
 ---
 
-### `showEditButton`
+### `showAccessory`
 
 Shows an edit button over the avatar (optional)
 


### PR DESCRIPTION
The prop for showing the Edit Button on the Avatar Component is not ```showEditButton```. It's actually ```showAccessory```.