### PR TITLE
Rename Github to GitHub

### DIFF
--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -147,7 +147,7 @@ Be sure to check out the documentation over at
 ## Implementing Bug Fixes and Improvements
 
 If you wish to submit a pull request for a new feature or issue then this is
-guide for you. On Github, we extensively use labels to reflect the content and
+guide for you. On GitHub, we extensively use labels to reflect the content and
 status of issues.
 
 For all issues that are bugs check

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -108,7 +108,7 @@ module.exports = {
           title: 'More',
           items: [
             {
-              label: 'Github',
+              label: 'GitHub',
               to: 'https://github.com/react-native-elements/react-native-elements'
             }
           ]

--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -21,7 +21,7 @@ const Help = props => {
       title: 'Join the community',
     },
     {
-      content: `Find out what's new for each release by checking the [releases tab on the Github repo.](https://github.com/react-native-elements/react-native-elements/releases)`,
+      content: `Find out what's new for each release by checking the [releases tab on the GitHub repo.](https://github.com/react-native-elements/react-native-elements/releases)`,
       title: 'Stay up to date',
     },
   ];
@@ -82,7 +82,7 @@ const Help = props => {
               </h2>
               <p className="padding-horiz--md">
                 Find out what's new for each release by checking the 
-                <a href="https://github.com/react-native-elements/react-native-elements/releases"> releases tab on the Github repo.</a>
+                <a href="https://github.com/react-native-elements/react-native-elements/releases"> releases tab on the GitHub repo.</a>
               </p>
             </div>
           </div>

--- a/website/versioned_docs/version-1.0.0/contributing.md
+++ b/website/versioned_docs/version-1.0.0/contributing.md
@@ -149,7 +149,7 @@ Be sure to check out the documentation over at
 ## Implementing Bug Fixes and Improvements
 
 If you wish to submit a pull request for a new feature or issue then this is
-guide for you. On Github, we extensively use labels to reflect the content and
+guide for you. On GitHub, we extensively use labels to reflect the content and
 status of issues.
 
 For all issues that are bugs check

--- a/website/versioned_docs/version-1.1.0/contributing.md
+++ b/website/versioned_docs/version-1.1.0/contributing.md
@@ -149,7 +149,7 @@ Be sure to check out the documentation over at
 ## Implementing Bug Fixes and Improvements
 
 If you wish to submit a pull request for a new feature or issue then this is
-guide for you. On Github, we extensively use labels to reflect the content and
+guide for you. On GitHub, we extensively use labels to reflect the content and
 status of issues.
 
 For all issues that are bugs check

--- a/website/versioned_docs/version-1.2.0/contributing.md
+++ b/website/versioned_docs/version-1.2.0/contributing.md
@@ -149,7 +149,7 @@ Be sure to check out the documentation over at
 ## Implementing Bug Fixes and Improvements
 
 If you wish to submit a pull request for a new feature or issue then this is
-guide for you. On Github, we extensively use labels to reflect the content and
+guide for you. On GitHub, we extensively use labels to reflect the content and
 status of issues.
 
 For all issues that are bugs check

--- a/website/versioned_docs/version-2.0.4/contributing.md
+++ b/website/versioned_docs/version-2.0.4/contributing.md
@@ -147,7 +147,7 @@ Be sure to check out the documentation over at
 ## Implementing Bug Fixes and Improvements
 
 If you wish to submit a pull request for a new feature or issue then this is
-guide for you. On Github, we extensively use labels to reflect the content and
+guide for you. On GitHub, we extensively use labels to reflect the content and
 status of issues.
 
 For all issues that are bugs check

--- a/website/versioned_docs/version-2.1/contributing.md
+++ b/website/versioned_docs/version-2.1/contributing.md
@@ -147,7 +147,7 @@ Be sure to check out the documentation over at
 ## Implementing Bug Fixes and Improvements
 
 If you wish to submit a pull request for a new feature or issue then this is
-guide for you. On Github, we extensively use labels to reflect the content and
+guide for you. On GitHub, we extensively use labels to reflect the content and
 status of issues.
 
 For all issues that are bugs check


### PR DESCRIPTION
There are different names for GitHub (`Github` and `GitHub`).
I unified the name to the correct one - `GitHub`.