### PR TITLE
- Fixes issue#2413 - Tooltip - Need support to disable auto hiding  of tooltip when touching/scrolling anywhere inside the active tooltip popover container

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1478,6 +1478,11 @@ export interface TooltipProps {
    * Force skip StatusBar height when calculating yOffset of element position (usable inside Modal on Android)
    */
   skipAndroidStatusBar?: boolean;
+
+  /**
+   * Disable auto hiding of tooltip when touching/scrolling anywhere inside the active tooltip popover container. Tooltip closes only when overlay backdrop is pressed (or) highlighted tooltip button is pressed
+   */
+  closeOnlyOnBackdropPress?: boolean;
 }
 
 export class Tooltip extends React.Component<TooltipProps, any> {

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import {
   TouchableOpacity,
@@ -118,15 +118,57 @@ class Tooltip extends React.PureComponent {
       </View>
     );
   };
+  renderTouchableHighlightedButton = () => {
+    const { highlightColor } = this.props;
+    const { yOffset, xOffset, elementWidth, elementHeight } = this.state;
+    return (
+      <TouchableOpacity
+        onPress={() => this.toggleTooltip()}
+        style={{
+          position: 'absolute',
+          top: yOffset,
+          [I18nManager.isRTL ? 'right' : 'left']: xOffset,
+          backgroundColor: highlightColor,
+          overflow: 'visible',
+          width: elementWidth,
+          height: elementHeight,
+        }}
+      >
+        {this.props.children}
+      </TouchableOpacity>
+    );
+  };
+  renderStaticHighlightedButton = () => {
+    const { highlightColor } = this.props;
+    const { yOffset, xOffset, elementWidth, elementHeight } = this.state;
+    return (
+      <View
+        style={{
+          position: 'absolute',
+          top: yOffset,
+          [I18nManager.isRTL ? 'right' : 'left']: xOffset,
+          backgroundColor: highlightColor,
+          overflow: 'visible',
+          width: elementWidth,
+          height: elementHeight,
+        }}
+      >
+        {this.props.children}
+      </View>
+    );
+  };
+
+  renderHighlightedButton = () => {
+    const { closeOnlyOnBackdropPress } = this.props;
+    if (closeOnlyOnBackdropPress) {
+      return this.renderTouchableHighlightedButton();
+    } else {
+      return this.renderStaticHighlightedButton();
+    }
+  };
 
   renderContent = (withTooltip) => {
-    const {
-      popover,
-      withPointer,
-      toggleOnPress,
-      toggleAction,
-      highlightColor,
-    } = this.props;
+    const { popover, withPointer, toggleOnPress, toggleAction } = this.props;
 
     if (!withTooltip) {
       return this.wrapWithPress(
@@ -136,23 +178,10 @@ class Tooltip extends React.PureComponent {
       );
     }
 
-    const { yOffset, xOffset, elementWidth, elementHeight } = this.state;
     const tooltipStyle = this.getTooltipStyle();
     return (
       <View>
-        <View
-          style={{
-            position: 'absolute',
-            top: yOffset,
-            [I18nManager.isRTL ? 'right' : 'left']: xOffset,
-            backgroundColor: highlightColor,
-            overflow: 'visible',
-            width: elementWidth,
-            height: elementHeight,
-          }}
-        >
-          {this.props.children}
-        </View>
+        {this.renderHighlightedButton()}
         {withPointer && this.renderPointer(tooltipStyle.top)}
         <View style={tooltipStyle} testID="tooltipPopoverContainer">
           {popover}
@@ -191,15 +220,48 @@ class Tooltip extends React.PureComponent {
       );
   };
 
+  renderStaticModalContent = () => {
+    const { withOverlay, overlayColor } = this.props;
+
+    return (
+      <Fragment>
+        <TouchableOpacity
+          style={styles.container(withOverlay, overlayColor)}
+          onPress={this.toggleTooltip}
+          activeOpacity={1}
+        />
+        <View style={styles.closeOnlyOnBackdropPressViewWrapper}>
+          {this.renderContent(true)}
+        </View>
+      </Fragment>
+    );
+  };
+  renderTogglingModalContent = () => {
+    const { withOverlay, overlayColor } = this.props;
+
+    return (
+      <TouchableOpacity
+        style={styles.container(withOverlay, overlayColor)}
+        onPress={this.toggleTooltip}
+        activeOpacity={1}
+      >
+        {this.renderContent(true)}
+      </TouchableOpacity>
+    );
+  };
+
+  renderModalContent = () => {
+    const { closeOnlyOnBackdropPress } = this.props;
+    if (closeOnlyOnBackdropPress) {
+      return this.renderStaticModalContent();
+    } else {
+      return this.renderTogglingModalContent();
+    }
+  };
+
   render() {
     const { isVisible } = this.state;
-    const {
-      onClose,
-      withOverlay,
-      overlayColor,
-      onOpen,
-      ModalComponent,
-    } = this.props;
+    const { onClose, onOpen, ModalComponent } = this.props;
 
     return (
       <View
@@ -217,13 +279,7 @@ class Tooltip extends React.PureComponent {
           onShow={onOpen}
           onRequestClose={onClose}
         >
-          <TouchableOpacity
-            style={styles.container(withOverlay, overlayColor)}
-            onPress={this.toggleTooltip}
-            activeOpacity={1}
-          >
-            {this.renderContent(true)}
-          </TouchableOpacity>
+          {this.renderModalContent()}
         </ModalComponent>
       </View>
     );
@@ -248,6 +304,7 @@ Tooltip.propTypes = {
   highlightColor: PropTypes.string,
   skipAndroidStatusBar: PropTypes.bool,
   ModalComponent: PropTypes.elementType,
+  closeOnlyOnBackdropPress: PropTypes.bool,
 };
 
 Tooltip.defaultProps = {
@@ -265,6 +322,7 @@ Tooltip.defaultProps = {
   onOpen: () => {},
   skipAndroidStatusBar: false,
   ModalComponent: Modal,
+  closeOnlyOnBackdropPress: false,
 };
 
 const styles = {
@@ -272,6 +330,9 @@ const styles = {
     backgroundColor: withOverlay ? overlayColor : 'transparent',
     flex: 1,
   }),
+  closeOnlyOnBackdropPressViewWrapper: {
+    position: 'absolute',
+  },
 };
 
 export { Tooltip };

--- a/website/docs/tooltip.md
+++ b/website/docs/tooltip.md
@@ -54,6 +54,7 @@ import Modal from 'modal-react-native-web';
 - [`toggleAction`](#toggleaction)
 - [`skipAndroidStatusBar`](#skipandroidstatusbar)
 - [`ModalComponent`](#modalcomponent)
+- [`closeOnlyOnBackdropPress`](#closeOnlyOnBackdropPress)
 
 ---
 
@@ -252,3 +253,15 @@ useEffect(() => {
   tooltipRef.current.toggleTooltip();
 }, []);
 ```
+
+---
+
+### `closeOnlyOnBackdropPress`
+
+Flag to determine whether to disable auto hiding of tooltip when touching/scrolling anywhere inside the active tooltip popover container. When `true`, Tooltip closes only when overlay backdrop is pressed (or) highlighted tooltip button is pressed
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---


### PR DESCRIPTION
**Fixes [issue#2413](https://github.com/react-native-elements/react-native-elements/issues/2413) - Tooltip - Need support to disable auto hiding of tooltip when touching/scrolling anywhere inside the active tooltip popover container**

- Added a configuration parameter **"closeOnlyOnBackdropPress"** to the tooltip

- **closeOnlyOnBackdropPress** -> default value is false -> default tooltip behaviour

- **closeOnlyOnBackdropPress** -> when set to true
    - Disables auto hiding of tooltip when touching/scrolling anywhere inside the active tooltip popover container
    - Tooltip closes only when overlay backdrop is pressed (or) highlighted tooltip button is pressed


 **Demo**

![react-native-elements-tooltip-fix](https://user-images.githubusercontent.com/30879156/89315419-17646b80-d67b-11ea-8ece-258d137a54d5.gif)
