### PR TITLE
deprecate ListItem subcomponents and avatar.accessory

### DIFF
--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -72,7 +72,7 @@ const AvatarComponent = ({
   const titleSize = width / 2;
   const iconSize = width / 2;
 
-  const accessorySize = accessory.size || width / 3;
+  const accessorySize = (accessory && accessory.size) || width / 3;
 
   const Utils = showAccessory && (
     <Accessory size={accessorySize} onPress={onAccessoryPress} {...accessory} />
@@ -218,7 +218,6 @@ AvatarComponent.defaultProps = {
   showAccessory: false,
   onAccessoryPress: null,
   size: 'small',
-  accessory: {},
   ImageComponent: RNImage,
 };
 

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -50,6 +50,22 @@ const AvatarComponent = ({
   children,
   ...attributes
 }) => {
+  if (accessory) {
+    console.warn(
+      "'Avatar.accessory' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (showAccessory) {
+    console.warn(
+      "'Avatar.showAccessory' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (onAccessoryPress) {
+    console.warn(
+      "'Avatar.onAccessoryPress' prop has been deprecated and will be removed in the next version."
+    );
+  }
+
   const width =
     typeof size === 'number' ? size : avatarSizes[size] || avatarSizes.small;
   const height = width;
@@ -205,6 +221,8 @@ AvatarComponent.defaultProps = {
   accessory: {},
   ImageComponent: RNImage,
 };
+
+AvatarComponent.Accessory = Accessory;
 
 const Avatar = React.memo(AvatarComponent, isEqual);
 export { Avatar };

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -221,8 +221,10 @@ AvatarComponent.defaultProps = {
   ImageComponent: RNImage,
 };
 
-AvatarComponent.Accessory = Accessory;
-
 const Avatar = React.memo(AvatarComponent, isEqual);
 export { Avatar };
-export default withTheme(Avatar, 'Avatar');
+const ThemedAvatar = withTheme(Avatar, 'Avatar');
+
+ThemedAvatar.Accessory = Accessory;
+
+export default ThemedAvatar;

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -13,33 +13,24 @@ import { withTheme } from '../config';
 
 import Avatar from '../avatar/Avatar';
 import Badge from '../badge/Badge';
-import CheckBox from '../checkbox/CheckBox';
 import Icon from '../icons/Icon';
 import Text from '../text/Text';
-import ButtonGroup from '../buttons/ButtonGroup';
-import Input from '../input/Input';
+
+import ListItemContent from './ListItemContent';
+import ListItemChevron from './ListItemChevron';
+import ListItemInput from './ListItemInput';
+import ListItemCheckBox from './ListItemCheckBox';
+import ListItemButtonGroup from './ListItemButtonGroup';
+import ListItemTitle from './ListItemTitle';
+import ListItemSubtitle from './ListItemSubtitle';
 
 const ANDROID_SECONDARY = 'rgba(0, 0, 0, 0.54)';
-
-const chevronDefaultProps = {
-  type: Platform.OS === 'ios' ? 'ionicon' : 'material',
-  color: '#D1D1D6',
-  name: Platform.OS === 'ios' ? 'ios-arrow-forward' : 'keyboard-arrow-right',
-  size: 16,
-  containerStyle: { alignSelf: 'center' },
-};
 
 const checkmarkDefaultProps = (theme) => ({
   name: 'check',
   size: 20,
   color: theme.colors.primary,
 });
-
-const renderText = (content, defaultProps, style) =>
-  renderNode(Text, content, {
-    ...defaultProps,
-    style: StyleSheet.flatten([style, defaultProps && defaultProps.style]),
-  });
 
 const renderAvatar = (content) =>
   renderNode(Avatar, content, {
@@ -96,8 +87,131 @@ const ListItem = (props) => {
       ? global.Expo.LinearGradient
       : View,
     theme,
+    children,
     ...attributes
   } = props;
+
+  if (title && title.trim().length === 0) {
+    console.warn(
+      "'ListItem.title' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (titleStyle) {
+    console.warn(
+      "'ListItem.titleStyle' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (titleProps) {
+    console.warn(
+      "'ListItem.titleProps' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (subtitle) {
+    console.warn(
+      "'ListItem.subtitle' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (subtitleStyle) {
+    console.warn(
+      "'ListItem.subtitleStyle' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (subtitleProps) {
+    console.warn(
+      "'ListItem.subtitleProps' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (leftIcon) {
+    console.warn(
+      "'ListItem.leftIcon' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (leftAvatar) {
+    console.warn(
+      "'ListItem.leftAvatar' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (leftElement) {
+    console.warn(
+      "'ListItem.leftElement' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (rightTitle) {
+    console.warn(
+      "'ListItem.rightTitle' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (rightTitleStyle) {
+    console.warn(
+      "'ListItem.rightTitleStyle' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (rightTitleProps) {
+    console.warn(
+      "'ListItem.rightTitleProps' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (rightSubtitle) {
+    console.warn(
+      "'ListItem.rightSubtitle' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (rightSubtitleStyle) {
+    console.warn(
+      "'ListItem.rightSubtitleStyle' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (rightSubtitleProps) {
+    console.warn(
+      "'ListItem.rightSubtitleProps' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (input) {
+    console.warn(
+      "'ListItem.input' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (buttonGroup) {
+    console.warn(
+      "'ListItem.buttonGroup' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (switchProps) {
+    console.warn(
+      "'ListItem.switch' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (checkBox) {
+    console.warn(
+      "'ListItem.checkBox' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (badge) {
+    console.warn(
+      "'ListItem.badge' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (chevron) {
+    console.warn(
+      "'ListItem.chevron' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (contentContainerStyle) {
+    console.warn(
+      "'ListItem.contentContainerStyle' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (rightContentContainerStyle) {
+    console.warn(
+      "'ListItem.rightContentContainerStyle' prop has been deprecated and will be removed in the next version."
+    );
+  }
+  if (checkmark) {
+    console.warn(
+      "'ListItem.checkmark' prop has been deprecated and will be removed in the next version."
+    );
+  }
+
   return (
     <Component
       {...attributes}
@@ -123,97 +237,50 @@ const ListItem = (props) => {
         {renderAvatar(leftAvatar)}
 
         {(typeof title !== 'undefined' || subtitle) && (
-          <View
-            style={StyleSheet.flatten([
-              styles.contentContainer,
-              contentContainerStyle,
-            ])}
-          >
-            {renderText(
-              title,
-              { testID: 'listItemTitle', ...titleProps },
-              StyleSheet.flatten([styles.title, titleStyle])
+          <ListItemContent style={contentContainerStyle}>
+            {title && (
+              <ListItemTitle style={titleStyle} {...titleProps}>
+                {title}
+              </ListItemTitle>
             )}
-            {renderText(
-              subtitle,
-              subtitleProps,
-              StyleSheet.flatten([styles.subtitle, subtitleStyle])
+            {subtitle && (
+              <ListItemSubtitle style={subtitleStyle} {...subtitleProps}>
+                {subtitle}
+              </ListItemSubtitle>
             )}
-          </View>
+          </ListItemContent>
         )}
 
         {(!!rightTitle || !!rightSubtitle) && (
-          <View
-            style={StyleSheet.flatten([
-              styles.rightContentContainer,
-              rightContentContainerStyle,
-            ])}
-          >
-            {renderText(
-              rightTitle,
-              rightTitleProps,
-              StyleSheet.flatten([
-                styles.title,
-                styles.rightTitle,
-                rightTitleStyle,
-              ])
+          <ListItemContent right style={rightContentContainerStyle}>
+            {rightTitle && (
+              <ListItemTitle right style={rightTitleStyle} {...rightTitleProps}>
+                {rightTitle}
+              </ListItemTitle>
             )}
-
-            {renderText(
-              rightSubtitle,
-              rightSubtitleProps,
-              StyleSheet.flatten([
-                styles.subtitle,
-                styles.rightSubtitle,
-                rightSubtitleStyle,
-              ])
+            {rightSubtitle && (
+              <ListItemSubtitle
+                right
+                style={rightSubtitleStyle}
+                {...rightSubtitleProps}
+              >
+                {rightSubtitle}
+              </ListItemSubtitle>
             )}
-          </View>
+          </ListItemContent>
         )}
 
-        {input && (
-          <Input
-            renderErrorMessage={false}
-            {...input}
-            inputStyle={StyleSheet.flatten([
-              styles.input,
-              input && input.inputStyle,
-            ])}
-            inputContainerStyle={StyleSheet.flatten([
-              styles.inputContentContainer,
-              input && input.inputContainerStyle,
-            ])}
-            containerStyle={StyleSheet.flatten([
-              styles.inputContainer,
-              input && input.containerStyle,
-            ])}
-          />
-        )}
+        {input && <ListItemInput {...input} />}
         {switchProps && <Switch {...switchProps} />}
-        {checkBox && (
-          <CheckBox
-            {...checkBox}
-            containerStyle={StyleSheet.flatten([
-              styles.checkboxContainer,
-              checkBox && checkBox.containerStyle,
-            ])}
-          />
-        )}
+        {checkBox && <ListItemCheckBox {...checkBox} />}
         {badge && <Badge {...badge} />}
-        {buttonGroup && (
-          <ButtonGroup
-            {...buttonGroup}
-            containerStyle={StyleSheet.flatten([
-              styles.buttonGroupContainer,
-              buttonGroup && buttonGroup.containerStyle,
-            ])}
-          />
-        )}
+        {buttonGroup && <ListItemButtonGroup {...buttonGroup} />}
         {renderAvatar(rightAvatar)}
         {renderIcon(rightIcon)}
         {renderNode(Text, rightElement)}
         {renderNode(Icon, checkmark, checkmarkDefaultProps(theme))}
-        {renderNode(Icon, chevron, chevronDefaultProps)}
+        {chevron && <ListItemChevron />}
+        {children}
       </PadView>
     </Component>
   );
@@ -234,72 +301,6 @@ const styles = {
     backgroundColor: 'white',
     borderColor: theme.colors.divider,
   }),
-  title: {
-    backgroundColor: 'transparent',
-    ...Platform.select({
-      ios: {
-        fontSize: 17,
-      },
-      default: {
-        fontSize: 16,
-      },
-    }),
-  },
-  subtitle: {
-    backgroundColor: 'transparent',
-    ...Platform.select({
-      ios: {
-        fontSize: 15,
-      },
-      default: {
-        color: ANDROID_SECONDARY,
-        fontSize: 14,
-      },
-    }),
-  },
-  contentContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'flex-start',
-  },
-  rightContentContainer: {
-    flex: 0.5,
-    justifyContent: 'center',
-    alignItems: 'flex-end',
-  },
-  inputContainer: {
-    flex: 1,
-    paddingRight: 0,
-  },
-  inputContentContainer: {
-    flex: 1,
-    borderBottomWidth: 0,
-    width: null,
-    height: null,
-  },
-  input: {
-    flex: 1,
-    textAlign: 'right',
-    width: null,
-    height: null,
-  },
-  checkboxContainer: {
-    margin: 0,
-    marginRight: 0,
-    marginLeft: 0,
-    padding: 0,
-  },
-  buttonGroupContainer: {
-    flex: 1,
-    marginHorizontal: 0,
-    marginVertical: 0,
-  },
-  rightTitle: {
-    color: ANDROID_SECONDARY,
-  },
-  rightSubtitle: {
-    color: ANDROID_SECONDARY,
-  },
 };
 
 ListItem.propTypes = {
@@ -354,6 +355,14 @@ ListItem.defaultProps = {
   pad: 16,
   title: '',
 };
+
+ListItem.Chevron = ListItemChevron;
+ListItem.Content = ListItemContent;
+ListItem.Input = ListItemInput;
+ListItem.Title = ListItemTitle;
+ListItem.Subtitle = ListItemSubtitle;
+ListItem.CheckBox = ListItemCheckBox;
+ListItem.ButtonGroup = ListItemButtonGroup;
 
 class PadView extends React.Component {
   constructor(props) {

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -236,37 +236,35 @@ const ListItem = (props) => {
         {renderIcon(leftIcon)}
         {renderAvatar(leftAvatar)}
 
-        {(typeof title !== 'undefined' || subtitle) && (
+        {(!!title || !!subtitle) && (
           <ListItemContent style={contentContainerStyle}>
-            {title && (
-              <ListItemTitle style={titleStyle} {...titleProps}>
-                {title}
-              </ListItemTitle>
-            )}
-            {subtitle && (
-              <ListItemSubtitle style={subtitleStyle} {...subtitleProps}>
-                {subtitle}
-              </ListItemSubtitle>
-            )}
+            {title &&
+              renderNode(ListItemTitle, title, {
+                style: titleStyle,
+                ...titleProps,
+              })}
+            {subtitle &&
+              renderNode(ListItemSubtitle, subtitle, {
+                style: subtitleStyle,
+                ...subtitleProps,
+              })}
           </ListItemContent>
         )}
 
         {(!!rightTitle || !!rightSubtitle) && (
           <ListItemContent right style={rightContentContainerStyle}>
-            {rightTitle && (
-              <ListItemTitle right style={rightTitleStyle} {...rightTitleProps}>
-                {rightTitle}
-              </ListItemTitle>
-            )}
-            {rightSubtitle && (
-              <ListItemSubtitle
-                right
-                style={rightSubtitleStyle}
-                {...rightSubtitleProps}
-              >
-                {rightSubtitle}
-              </ListItemSubtitle>
-            )}
+            {rightTitle &&
+              renderNode(ListItemTitle, rightTitle, {
+                right: true,
+                style: rightTitleStyle,
+                ...rightTitleProps,
+              })}
+            {rightSubtitle &&
+              renderNode(ListItemSubtitle, rightSubtitle, {
+                right: true,
+                style: rightSubtitleStyle,
+                ...rightSubtitleProps,
+              })}
           </ListItemContent>
         )}
 
@@ -356,14 +354,6 @@ ListItem.defaultProps = {
   title: '',
 };
 
-ListItem.Chevron = ListItemChevron;
-ListItem.Content = ListItemContent;
-ListItem.Input = ListItemInput;
-ListItem.Title = ListItemTitle;
-ListItem.Subtitle = ListItemSubtitle;
-ListItem.CheckBox = ListItemCheckBox;
-ListItem.ButtonGroup = ListItemButtonGroup;
-
 class PadView extends React.Component {
   constructor(props) {
     super(props);
@@ -401,4 +391,13 @@ PadView.propTypes = {
 };
 
 export { ListItem };
-export default withTheme(ListItem, 'ListItem');
+
+const ThemedListItem = withTheme(ListItem, 'ListItem');
+ThemedListItem.Chevron = ListItemChevron;
+ThemedListItem.Content = ListItemContent;
+ThemedListItem.Input = ListItemInput;
+ThemedListItem.Title = ListItemTitle;
+ThemedListItem.Subtitle = ListItemSubtitle;
+ThemedListItem.CheckBox = ListItemCheckBox;
+ThemedListItem.ButtonGroup = ListItemButtonGroup;
+export default ThemedListItem;

--- a/src/list/ListItemButtonGroup.js
+++ b/src/list/ListItemButtonGroup.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import ButtonGroup from '../buttons/ButtonGroup';
+
+function ListItemButtonGroup({ containerStyle, ...props }) {
+  return (
+    <ButtonGroup
+      {...props}
+      containerStyle={StyleSheet.flatten([styles.container, containerStyle])}
+    />
+  );
+}
+
+const styles = {
+  container: {
+    flex: 1,
+    marginHorizontal: 0,
+    marginVertical: 0,
+  },
+};
+
+export default ListItemButtonGroup;

--- a/src/list/ListItemCheckBox.js
+++ b/src/list/ListItemCheckBox.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import CheckBox from '../checkbox/CheckBox';
+
+function ListItemCheckBox({ containerStyle, ...props }) {
+  return (
+    <CheckBox
+      {...props}
+      containerStyle={StyleSheet.flatten([styles.container, containerStyle])}
+    />
+  );
+}
+
+const styles = {
+  container: {
+    margin: 0,
+    marginRight: 0,
+    marginLeft: 0,
+    padding: 0,
+  },
+};
+
+export default ListItemCheckBox;

--- a/src/list/ListItemChevron.js
+++ b/src/list/ListItemChevron.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { StyleSheet, Platform } from 'react-native';
+import Icon from '../icons/Icon';
+
+function ListItemChevron({ containerStyle, ...props }) {
+  return (
+    <Icon
+      type={Platform.OS === 'ios' ? 'ionicon' : 'material'}
+      color="#D1D1D6"
+      name={
+        Platform.OS === 'ios' ? 'ios-arrow-forward' : 'keyboard-arrow-right'
+      }
+      size={16}
+      containerStyle={StyleSheet.flatten([
+        { alignSelf: 'center' },
+        containerStyle,
+      ])}
+      {...props}
+    />
+  );
+}
+
+export default ListItemChevron;

--- a/src/list/ListItemContent.js
+++ b/src/list/ListItemContent.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+function ListItemContent({ style, right, children, ...props }) {
+  const containerStyle = right ? styles.rightContainer : styles.container;
+  return (
+    <View style={StyleSheet.flatten([containerStyle, style])} {...props}>
+      {children}
+    </View>
+  );
+}
+
+const styles = {
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+  },
+  rightContainer: {
+    flex: 0.5,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+};
+
+export default ListItemContent;

--- a/src/list/ListItemInput.js
+++ b/src/list/ListItemInput.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import Input from '../input/Input';
+
+function ListItemInput({
+  inputStyle,
+  inputContainerStyle,
+  containerStyle,
+  ...props
+}) {
+  return (
+    <Input
+      renderErrorMessage={false}
+      {...props}
+      inputStyle={StyleSheet.flatten([styles.input, inputStyle])}
+      inputContainerStyle={StyleSheet.flatten([
+        styles.inputContainer,
+        inputContainerStyle,
+      ])}
+      containerStyle={StyleSheet.flatten([styles.container, containerStyle])}
+    />
+  );
+}
+
+const styles = {
+  container: {
+    flex: 1,
+    paddingRight: 0,
+  },
+  inputContainer: {
+    flex: 1,
+    borderBottomWidth: 0,
+    width: null,
+    height: null,
+  },
+  input: {
+    flex: 1,
+    textAlign: 'right',
+    width: null,
+    height: null,
+  },
+};
+
+export default ListItemInput;

--- a/src/list/ListItemSubtitle.js
+++ b/src/list/ListItemSubtitle.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { StyleSheet, Platform } from 'react-native';
+import Text from '../text/Text';
+
+const ANDROID_SECONDARY = 'rgba(0, 0, 0, 0.54)';
+
+function ListItemSubtitle({ style, right, children, ...props }) {
+  return (
+    <Text
+      testID="listItemTitle"
+      style={StyleSheet.flatten([
+        styles.subtitle,
+        right && styles.rightSubtitle,
+        style,
+      ])}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+}
+
+const styles = {
+  subtitle: {
+    backgroundColor: 'transparent',
+    ...Platform.select({
+      ios: {
+        fontSize: 15,
+      },
+      default: {
+        color: ANDROID_SECONDARY,
+        fontSize: 14,
+      },
+    }),
+  },
+
+  rightSubtitle: {
+    color: ANDROID_SECONDARY,
+  },
+};
+
+export default ListItemSubtitle;

--- a/src/list/ListItemTitle.js
+++ b/src/list/ListItemTitle.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { StyleSheet, Platform } from 'react-native';
+import Text from '../text/Text';
+
+const ANDROID_SECONDARY = 'rgba(0, 0, 0, 0.54)';
+
+function ListItemTitle({ style, right, children, ...props }) {
+  return (
+    <Text
+      testID="listItemTitle"
+      style={StyleSheet.flatten([
+        styles.title,
+        right && styles.rightTitle,
+        style,
+      ])}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+}
+
+const styles = {
+  title: {
+    backgroundColor: 'transparent',
+    ...Platform.select({
+      ios: {
+        fontSize: 17,
+      },
+      default: {
+        fontSize: 16,
+      },
+    }),
+  },
+  rightTitle: {
+    color: ANDROID_SECONDARY,
+  },
+};
+
+export default ListItemTitle;

--- a/src/list/__tests__/__snapshots__/ListItem.js.snap
+++ b/src/list/__tests__/__snapshots__/ListItem.js.snap
@@ -103,15 +103,7 @@ exports[`ListItem component should render with avatar 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "alignItems": "flex-start",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    />
+    <ListItemContent />
   </PadView>
 </View>
 `;
@@ -131,40 +123,9 @@ exports[`ListItem component should render with input 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "alignItems": "flex-start",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    />
-    <ForwardRef(Themed.Input)
-      containerStyle={
-        Object {
-          "flex": 1,
-          "paddingRight": 0,
-        }
-      }
-      inputContainerStyle={
-        Object {
-          "borderBottomWidth": 0,
-          "flex": 1,
-          "height": null,
-          "width": null,
-        }
-      }
-      inputStyle={
-        Object {
-          "flex": 1,
-          "height": null,
-          "textAlign": "right",
-          "width": null,
-        }
-      }
+    <ListItemContent />
+    <ListItemInput
       placeholder="Enter Text"
-      renderErrorMessage={false}
     />
   </PadView>
 </View>
@@ -191,15 +152,7 @@ exports[`ListItem component should render with left icon 1`] = `
       size={20}
       type="font-awesome"
     />
-    <View
-      style={
-        Object {
-          "alignItems": "flex-start",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    />
+    <ListItemContent />
   </PadView>
 </View>
 `;
@@ -222,15 +175,7 @@ exports[`ListItem component should render with left icon component 1`] = `
     <Text>
       I'm left icon
     </Text>
-    <View
-      style={
-        Object {
-          "alignItems": "flex-start",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    />
+    <ListItemContent />
   </PadView>
 </View>
 `;
@@ -250,15 +195,7 @@ exports[`ListItem component should render with right icon component 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "alignItems": "flex-start",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    />
+    <ListItemContent />
     <Text>
       I'm right icon
     </Text>
@@ -283,29 +220,11 @@ exports[`ListItem component should render with switch 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "alignItems": "flex-start",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    />
+    <ListItemContent />
     <Switch
       value={true}
     />
-    <Themed.Icon
-      color="#D1D1D6"
-      containerStyle={
-        Object {
-          "alignSelf": "center",
-        }
-      }
-      name="ios-arrow-forward"
-      size={16}
-      type="ionicon"
-    />
+    <ListItemChevron />
   </PadView>
 </View>
 `;
@@ -325,59 +244,36 @@ exports[`ListItem component should render with title and subtitle 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "alignItems": "flex-start",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    >
-      <Themed.Text
+    <ListItemContent>
+      <ListItemTitle
         numberOfLines={5}
         style={
           Object {
             "backgroundColor": "peru",
-            "fontSize": 17,
           }
         }
-        testID="listItemTitle"
       >
         title test
-      </Themed.Text>
-      <Themed.Text
+      </ListItemTitle>
+      <ListItemSubtitle
         style={
           Object {
             "backgroundColor": "peru",
-            "fontSize": 15,
           }
         }
       >
         title test
-      </Themed.Text>
-    </View>
-    <View
-      style={
-        Object {
-          "alignItems": "flex-end",
-          "flex": 0.5,
-          "justifyContent": "center",
-        }
-      }
+      </ListItemSubtitle>
+    </ListItemContent>
+    <ListItemContent
+      right={true}
     >
-      <Themed.Text
-        style={
-          Object {
-            "backgroundColor": "transparent",
-            "color": "rgba(0, 0, 0, 0.54)",
-            "fontSize": 17,
-          }
-        }
+      <ListItemTitle
+        right={true}
       >
         title
-      </Themed.Text>
-    </View>
+      </ListItemTitle>
+    </ListItemContent>
   </PadView>
 </View>
 `;
@@ -397,15 +293,7 @@ exports[`ListItem component should render without issues 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "alignItems": "flex-start",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    />
+    <ListItemContent />
   </PadView>
 </View>
 `;

--- a/src/list/__tests__/__snapshots__/ListItem.js.snap
+++ b/src/list/__tests__/__snapshots__/ListItem.js.snap
@@ -102,9 +102,7 @@ exports[`ListItem component should render with avatar 1`] = `
         "padding": 14,
       }
     }
-  >
-    <ListItemContent />
-  </PadView>
+  />
 </View>
 `;
 
@@ -123,7 +121,6 @@ exports[`ListItem component should render with input 1`] = `
       }
     }
   >
-    <ListItemContent />
     <ListItemInput
       placeholder="Enter Text"
     />
@@ -152,7 +149,6 @@ exports[`ListItem component should render with left icon 1`] = `
       size={20}
       type="font-awesome"
     />
-    <ListItemContent />
   </PadView>
 </View>
 `;
@@ -175,7 +171,6 @@ exports[`ListItem component should render with left icon component 1`] = `
     <Text>
       I'm left icon
     </Text>
-    <ListItemContent />
   </PadView>
 </View>
 `;
@@ -195,7 +190,6 @@ exports[`ListItem component should render with right icon component 1`] = `
       }
     }
   >
-    <ListItemContent />
     <Text>
       I'm right icon
     </Text>
@@ -220,7 +214,6 @@ exports[`ListItem component should render with switch 1`] = `
       }
     }
   >
-    <ListItemContent />
     <Switch
       value={true}
     />
@@ -292,8 +285,6 @@ exports[`ListItem component should render without issues 1`] = `
         "padding": 14,
       }
     }
-  >
-    <ListItemContent />
-  </PadView>
+  />
 </View>
 `;

--- a/website/blog/2020-08-10-2.3-upgrade-guide.md
+++ b/website/blog/2020-08-10-2.3-upgrade-guide.md
@@ -1,0 +1,81 @@
+---
+title: Version 2.3 Upgrade Guide
+author: Core Team
+authorURL: https://opencollective.com/react-native-elements#team
+---
+
+There have been a lot of changes and improvements coming through the pipeline recently with `react-native-elements`. So in preparing for a version 3, there are some planned deprecations that will be added into version 2.3 and then removed in version 3.
+
+The reason for these changes is that `react-native-elements` regularly gets requests for new features and enhancements quite frequently. The fast and easy method of adding these new features is usually to add another prop into the component that then injects some change into a child component. Unfortunately, this ends up leading to the components having a lot of props, lots of conditional code, and additional code complexity. The solution going forward and into version 3 will be to break down large components into smaller pieces so that it is easier to inject your own code without having to wait for an additional prop to be added.
+
+As we continue to build up to version 3, this post will continue to be updated with new step-by-step directions on how to upgrade your code to work around these changes. The RNE team thanks you for your patience, and we hope that you see the value in the upcoming changes.
+
+## Avatar
+
+`accessory`, `showAccessory`, and `accessoryProps` are all being dprecated. There is now a child component `Avatar.Accessory` that you insert as a child component instead.
+
+```js
+<Avatar>
+  <Avatar.Accessory {...accessoryProps} />
+</Avatar>
+```
+
+## ListItem
+
+`ListItem` has a large number of deprecated props. `ListItem` has been somewhat of a kitchen sink. All the props can be replaced by inserting them as children in the order of left to right as they appear on the screen.
+
+### leftElement, leftIcon, leftAvatar, rightElement, rightIcon, rightAvatar
+
+These can be replaced by using `Text`, `Icon`, and `Avatar` components respectively.
+
+### title, titleStyle, titleProps, subtitle, subtitleProps, subtitleStyle
+
+These props can be replaced by `ListItem.Content`, `ListItem.Title` and `ListItem.Subtitle`
+
+```js
+<ListItem>
+  <ListItem.Content>
+    <ListItem.Title style={titleStyle} {...titleProps}>
+      {title}
+    </ListItem.Title>
+  </ListItem.Content>
+</ListItem>
+```
+
+### contentContainerStyle, rightContentContainerStyle
+
+These props should be placed in the `style` prop of `ListItem.Content`.
+
+### rightTitle, rightTitleStyle, rightTitleProps, rightSubtitle, rightSubtitleStyle, rightSubtitleProps
+
+These props also use `ListItem.Content`, `ListItem.Title`, and `ListItem.Subtitle`. Simply add the prop `right` to each one.
+
+```js
+<ListItem>
+  <ListItem.Content right>
+    <ListItem.Title right style={titleStyle} {...titleProps}>
+      {title}
+    </ListItem.Title>
+  </ListItem.Content>
+</ListItem>
+```
+
+### input, buttonGroup, switchProps, checkBox, badge, chevron, checkmark
+
+The `input` prop can be replaced with `ListItem.Input`.
+
+The `buttonGroup` prop can be replaced with `ListItem.ButtonGroup`.
+
+The `switchProps` prop can be replaced with `react-native`'s `Switch`.
+
+The `checkBox` prop can be replaced with `ListItem.CheckBox`.
+
+The `badge` prop can be replaced with `Badge`.
+
+The `chevron` prop can be replaced with `ListItem.Chevron`.
+
+The `checkmark` prop can be replaced with :
+
+```js
+<Icon name="check" size={20} />
+```

--- a/website/docs/avatar.md
+++ b/website/docs/avatar.md
@@ -191,11 +191,11 @@ import { ListItem } from 'react-native-elements';
 
 ---
 
-## Child Props
+## Child Components
 
 ### Accessory
 
-> Receives either all `Icon` or `Image` props.
+> Receives either all [Icon](icon.md#props) or [Image](image.md#props) props.
 
 ---
 

--- a/website/docs/badge.md
+++ b/website/docs/badge.md
@@ -200,7 +200,7 @@ Text value to be displayed by badge, defaults to empty
 ### `options`
 
 > Also receives all
-> [Badge](https://facebook.github.io/react-native/docs/badge#props) props.
+> [Badge](badge.md#props) props.
 
 Object with the following (optional) keys:
 

--- a/website/docs/listitem.md
+++ b/website/docs/listitem.md
@@ -16,7 +16,7 @@ avatars, badges, icons, and more.
 ### Using Map Function - Implemented with avatar
 
 ```js
-import { ListItem } from 'react-native-elements'
+import { ListItem, Avatar } from 'react-native-elements'
 
 const list = [
   {
@@ -35,13 +35,13 @@ const list = [
 <View>
   {
     list.map((l, i) => (
-      <ListItem
-        key={i}
-        leftAvatar={{ source: { uri: l.avatar_url } }}
-        title={l.name}
-        subtitle={l.subtitle}
-        bottomDivider
-      />
+      <ListItem key={i} bottomDivider>
+        <Avatar source={{uri: l.avatar_url}} />
+        <ListItem.Content>
+          <ListItem.Title>{l.name}</ListItem.Title>
+          <ListItem.Subtitle>{l.subtitle}</ListItem.Subtitle>
+        </ListItem.Content>
+      </ListItem>
     ))
   }
 </View>
@@ -50,7 +50,7 @@ const list = [
 ### Using Map Function - Implemented with link and icon
 
 ```js
-import { ListItem } from 'react-native-elements'
+import { ListItem, Icon } from 'react-native-elements'
 
 const list = [
   {
@@ -67,13 +67,13 @@ const list = [
 <View>
   {
     list.map((item, i) => (
-      <ListItem
-        key={i}
-        title={item.title}
-        leftIcon={{ name: item.icon }}
-        bottomDivider
-        chevron
-      />
+      <ListItem key={i} bottomDivider>
+        <Icon name={item.icon} />
+        <ListItem.Content>
+          <ListItem.Title>{item.title}</ListItem.Title>
+        </ListItem.Content>
+        <ListItem.Chevron />
+      </ListItem>
     ))
   }
 </View>
@@ -82,7 +82,7 @@ const list = [
 ### Using RN FlatList - Implemented with link and avatar
 
 ```js
-import { ListItem } from 'react-native-elements'
+import { ListItem, Avatar } from 'react-native-elements'
 
 const list = [
   {
@@ -101,13 +101,14 @@ const list = [
 keyExtractor = (item, index) => index.toString()
 
 renderItem = ({ item }) => (
-  <ListItem
-    title={item.name}
-    subtitle={item.subtitle}
-    leftAvatar={{ source: { uri: item.avatar_url } }}
-    bottomDivider
-    chevron
-  />
+  <ListItem bottomDivider>
+    <Avatar source={{uri: item.avatar_url}} />
+    <ListItem.Content>
+      <ListItem.Title>{item.name}</ListItem.Title>
+      <ListItem.Subtitle>{item.subtitle}</ListItem.Subtitle>
+    </ListItem.Content>
+    <ListItem.Chevron />
+  </ListItem>
 )
 
 render () {
@@ -124,7 +125,7 @@ render () {
 ### Using RN FlatList - Implemented with custom avatar component.
 
 ```js
-import { ListItem } from 'react-native-elements'
+import { ListItem, Avatar } from 'react-native-elements'
 
 const list = [
   {
@@ -142,16 +143,14 @@ const list = [
 keyExtractor = (item, index) => index.toString()
 
 renderItem = ({ item }) => (
-  <ListItem
-    title={item.name}
-    subtitle={item.subtitle}
-    leftAvatar={{
-      source: item.avatar_url && { uri: item.avatar_url },
-      title: item.name[0]
-    }}
-    bottomDivider
-    chevron
-  />
+  <ListItem bottomDivider >
+    <Avatar title={item.name[0]} source={item.avatar_url && { uri: item.avatar_url }}/>
+    <ListItem.Content>
+      <ListItem.Title>{item.name}</ListItem.Title>
+      <ListItem.Subtitle>{item.subtitle}</ListItem.Subtitle>
+    </ListItem.Content>
+    <ListItem.Chevron />
+  </ListItem>
 )
 
 render () {
@@ -168,20 +167,20 @@ render () {
 ### ListItem implemented with custom View for Subtitle
 
 ```js
-import { ListItem } from 'react-native-elements'
+import { ListItem, Avatar } from 'react-native-elements'
 
 render () {
   return (
-    <ListItem
-      title='Limited supply! Its like digital gold!'
-      subtitle={
+    <ListItem>
+      <Avatar source={require('../images/avatar1.jpg')} />
+      <ListItem.Content>
+        <ListItem.Title>Limited supply! Its like digital gold!</ListItem.Title>
         <View style={styles.subtitleView}>
           <Image source={require('../images/rating.png')} style={styles.ratingImage}/>
           <Text style={styles.ratingText}>5 months ago</Text>
         </View>
-      }
-      leftAvatar={{ source: require('../images/avatar1.jpg') }}
-    />
+      </ListItem.Content>
+    </ListItem>
   )
 }
 
@@ -209,10 +208,13 @@ styles = StyleSheet.create({
 Example badge usage
 
 ```js
-<ListItem
-  ...
-  badge={{ value: 3, textStyle: { color: 'orange' }, containerStyle: { marginTop: -20 } }}
-/>
+<ListItem>
+  <Badge
+    value={3}
+    textStyle={{ color: 'orange' }}
+    containerStyle={{ marginTop: -20 }}
+  />
+</ListItem>
 ```
 
 ### Linear gradient + Scale feedback
@@ -220,6 +222,7 @@ Example badge usage
 <img src="/react-native-elements/img/listitem_with_gradient_scale.gif" width="500" />
 
 ```js
+import { ListItem, Avatar } from 'react-native-elements';
 import TouchableScale from 'react-native-touchable-scale'; // https://github.com/kohver/react-native-touchable-scale
 import LinearGradient from 'react-native-linear-gradient'; // Only if no expo
 
@@ -234,13 +237,18 @@ import LinearGradient from 'react-native-linear-gradient'; // Only if no expo
     end: { x: 0.2, y: 0 },
   }}
   ViewComponent={LinearGradient} // Only if no expo
-  leftAvatar={{ rounded: true, source: { uri: avatar_url } }}
-  title="Chris Jackson"
-  titleStyle={{ color: 'white', fontWeight: 'bold' }}
-  subtitleStyle={{ color: 'white' }}
-  subtitle="Vice Chairman"
-  chevron={{ color: 'white' }}
-/>;
+>
+  <Avatar rounded source={{ uri: avatar_url }} />
+  <ListItem.Content>
+    <ListItem.Title style={{ color: 'white', fontWeight: 'bold' }}>
+      Chris Jackson
+    </ListItem.Title>
+    <ListItem.Subtitle style={{ color: 'white' }}>
+      Vice Chairman
+    </ListItem.Subtitle>
+  </ListItem.Content>
+  <ListItem.Chevron color="white" />
+</ListItem>;
 ```
 
 ---
@@ -253,35 +261,8 @@ import LinearGradient from 'react-native-linear-gradient'; // Only if no expo
 
 - [`Component`](#Component)
 - [`containerStyle`](#containerstyle)
-- [`contentContainerStyle`](#contentcontainerstyle)
-- [`rightContentContainerStyle`](#rightcontentcontainerstyle)
-- [`chevron`](#chevron)
-- [`checkmark`](#checkmark)
 - [`onPress`](#onpress)
 - [`onLongPress`](#onlongpress)
-- [`title`](#title)
-- [`titleStyle`](#titlestyle)
-- [`titleProps`](#titleprops)
-- [`subtitle`](#subtitle)
-- [`subtitleStyle`](#subtitlestyle)
-- [`subtitleProps`](#subtitleprops)
-- [`rightTitle`](#righttitle)
-- [`rightTitleStyle`](#righttitlestyle)
-- [`rightTitleProps`](#righttitleprops)
-- [`rightSubtitle`](#rightsubtitle)
-- [`rightSubtitleStyle`](#rightsubtitlestyle)
-- [`rightSubtitleProps`](#rightsubtitleprops)
-- [`leftIcon`](#lefticon)
-- [`rightIcon`](#righticon)
-- [`leftAvatar`](#leftavatar)
-- [`rightAvatar`](#rightavatar)
-- [`leftElement`](#leftelement)
-- [`rightElement`](#rightelement)
-- [`switch`](#switch)
-- [`input`](#input)
-- [`buttonGroup`](#buttongroup)
-- [`checkBox`](#checkbox)
-- [`badge`](#badge)
 - [`disabled`](#disabled)
 - [`disabledStyle`](#disabledstyle)
 - [`topDivider`](#topdivider)
@@ -290,6 +271,36 @@ import LinearGradient from 'react-native-linear-gradient'; // Only if no expo
 - [`pad`](#pad)
 
 ---
+
+## Child Components
+
+### ListItem.ButtonGroup
+
+> Receives all [ButtonGroup](button_group.md#props) props.
+
+### ListItem.CheckBox
+
+> Receives all [CheckBox](checkbox.md#props) props.
+
+### ListItem.Chevron
+
+> Receives all [Icon](icon.md#props) props.
+
+### ListItem.Content
+
+> Receives all [View](https://reactnative.dev/docs/view#props) props.
+
+### ListItem.Input
+
+> Receives all [Input](input.md#props) props.
+
+### ListItem.Subtitle
+
+> Receives all [Text](text.md#props) props.
+
+### ListItem.Title
+
+> Receives all [Text](text.md#props) props.
 
 ## Reference
 
@@ -313,46 +324,6 @@ additional main container styling (optional)
 
 ---
 
-### `contentContainerStyle`
-
-additional wrapper styling (title and subtitle container)
-
-|      Type      | Default |
-| :------------: | :-----: |
-| object (style) |  none   |
-
----
-
-### `rightContentContainerStyle`
-
-additional wrapper styling (right title and subtitle container)
-
-|      Type      | Default |
-| :------------: | :-----: |
-| object (style) |  none   |
-
----
-
-### `chevron`
-
-set it to true or custom icon props if you want a chevron (optional)
-
-|                                       Type                                        | Default |
-| :-------------------------------------------------------------------------------: | :-----: |
-| boolean **OR** {[...Icon props](icon.md#props)} **OR** React element or component |  none   |
-
----
-
-### `checkmark`
-
-set it to true or custom icon props if you want a checkmark (optional)
-
-|                                       Type                                        | Default |
-| :-------------------------------------------------------------------------------: | :-----: |
-| boolean **OR** {[...Icon props](icon.md#props)} **OR** React element or component |  none   |
-
----
-
 ### `onPress`
 
 onPress method for link (optional)
@@ -370,241 +341,6 @@ onLongPress method for link (optional)
 |   Type   | Default |
 | :------: | :-----: |
 | function |  none   |
-
----
-
-### `title`
-
-Main title of list item
-
-|            Type             | Default |
-| :-------------------------: | :-----: |
-| string **OR** React element |  none   |
-
----
-
-### `titleStyle`
-
-Add additional styling
-
-|    Type    | Default |
-| :--------: | :-----: |
-| Text style |  none   |
-
----
-
-### `titleProps`
-
-provide all props from react-native Text component
-
-|                                      Type                                       | Default |
-| :-----------------------------------------------------------------------------: | :-----: |
-| {[...Text props](https://facebook.github.io/react-native/docs/text.html#props)} |  none   |
-
----
-
-### `subtitle`
-
-subtitle text or custom view (optional)
-
-|            Type             | Default |
-| :-------------------------: | :-----: |
-| string **OR** React element |  none   |
-
----
-
-### `subtitleStyle`
-
-Add additional styling
-
-|    Type    | Default |
-| :--------: | :-----: |
-| Text style |  none   |
-
----
-
-### `subtitleProps`
-
-provide all props from react-native Text component
-
-|                                      Type                                       | Default |
-| :-----------------------------------------------------------------------------: | :-----: |
-| {[...Text props](https://facebook.github.io/react-native/docs/text.html#props)} |  none   |
-
----
-
-### `rightTitle`
-
-Show up a title on the right side of the list item
-
-|            Type             | Default |
-| :-------------------------: | :-----: |
-| string **OR** React element |  none   |
-
----
-
-### `rightTitleStyle`
-
-add additional styling
-
-|    Type    | Default |
-| :--------: | :-----: |
-| Text style |  none   |
-
----
-
-### `rightTitleProps`
-
-provide all props from react-native Text component
-
-|                                      Type                                       | Default |
-| :-----------------------------------------------------------------------------: | :-----: |
-| {[...Text props](https://facebook.github.io/react-native/docs/text.html#props)} |  none   |
-
----
-
-### `rightSubtitle`
-
-Show up a subtitle on the right side of the list item
-
-|            Type             | Default |
-| :-------------------------: | :-----: |
-| string **OR** React element |  none   |
-
----
-
-### `rightSubtitleStyle`
-
-Add additional styling
-
-|    Type    | Default |
-| :--------: | :-----: |
-| Text style |  none   |
-
----
-
-### `rightSubtitleProps`
-
-provide all props from react-native Text component
-
-|                                      Type                                       | Default |
-| :-----------------------------------------------------------------------------: | :-----: |
-| {[...Text props](https://facebook.github.io/react-native/docs/text.html#props)} |  none   |
-
----
-
-### `leftIcon`
-
-displays an icon on the left (optional)
-
-|                            Type                            | Default |
-| :--------------------------------------------------------: | :-----: |
-| {[...Icon props](icon.md#props)}<br/>**OR**<br/> component |  none   |
-
----
-
-### `rightIcon`
-
-displays an icon on the right (optional)
-
-|                            Type                            | Default |
-| :--------------------------------------------------------: | :-----: |
-| {[...Icon props](icon.md#props)}<br/>**OR**<br/> component |  none   |
-
----
-
-### `leftAvatar`
-
-displays an Avatar on the left (optional)
-
-|                              Type                              | Default |
-| :------------------------------------------------------------: | :-----: |
-| {[...Avatar props](avatar.md#props)}<br/>**OR**<br/> component |  none   |
-
----
-
-### `rightAvatar`
-
-displays an Avatar on the right (optional)
-
-|                                       Type                                        | Default |
-| :-------------------------------------------------------------------------------: | :-----: |
-| View style (object){[...Avatar props](avatar.md#props)}<br/>**OR**<br/> component |  none   |
-
----
-
-### `leftElement`
-
-Add any element on the left side of the list item
-
-|     Type      | Default |
-| :-----------: | :-----: |
-| React element |  none   |
-
----
-
-### `rightElement`
-
-Add any element on the right side of the list item
-
-|     Type      | Default |
-| :-----------: | :-----: |
-| React element |  none   |
-
----
-
-### `switch`
-
-add a switch to the right side. (object with the props of the react-native
-`Switch` component)
-
-|                                        Type                                         | Default |
-| :---------------------------------------------------------------------------------: | :-----: |
-| {[...Switch props](https://facebook.github.io/react-native/docs/switch.html#props)} |  none   |
-
----
-
-### `input`
-
-add an Input on the right side (object with the props of the React Native
-Elements `Input` component)
-
-|                Type                | Default |
-| :--------------------------------: | :-----: |
-| {[...Input props](input.md#props)} |  none   |
-
----
-
-### `buttonGroup`
-
-add a button group on the right side (object with the props of the React Native
-Elements `ButtonGroup` component)
-
-|                      Type                       | Default |
-| :---------------------------------------------: | :-----: |
-| {[...ButtonGroup props](button_group.md#props)} |  none   |
-
----
-
-### `checkBox`
-
-add a checkbox on the right side (object with the props of the React Native
-Elements `CheckBox` component)
-
-|                   Type                   | Default |
-| :--------------------------------------: | :-----: |
-| {[...CheckBox props](checkbox.md#props)} |  none   |
-
----
-
-### `badge`
-
-add a badge on the right side (object with the props of the React Native
-Elements `Badge` component)
-
-|                Type                | Default |
-| :--------------------------------: | :-----: |
-| {[...Badge props](badge.md#props)} |  none   |
 
 ---
 


### PR DESCRIPTION
Fixes: #2459
Remove `ListItem` sub-components, deprecate props.
Also deprecates `Avatar` accessory props.

TODO: 
1. double check that example continues to work
2. write blog post detailing upgrade details