### PR TITLE
FIX - 814 - Clickable image on the cards 

### DIFF
--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -6,6 +6,10 @@ import {
   StyleSheet,
   View,
   Platform,
+  TouchableOpacity,
+  TouchableHighlight,
+  TouchableNativeFeedback,
+  TouchableWithoutFeedback,
 } from 'react-native';
 
 import { nodeType } from '../helpers';
@@ -43,6 +47,9 @@ class Image extends React.Component {
 
   render() {
     const {
+      onPress,
+      onLongPress,
+      Component = onPress || onLongPress ? TouchableOpacity : View,
       placeholderStyle,
       PlaceholderContent,
       containerStyle,
@@ -55,7 +62,9 @@ class Image extends React.Component {
     const { width, height, ...styleProps } = style;
 
     return (
-      <View
+      <Component
+        onPress={onPress}
+        onLongPress={onLongPress}
         accessibilityIgnoresInvertColors={true}
         style={StyleSheet.flatten([styles.container, containerStyle])}
       >
@@ -97,7 +106,7 @@ class Image extends React.Component {
         </Animated.View>
 
         <View style={style}>{children}</View>
-      </View>
+      </Component>
     );
   }
 }
@@ -120,6 +129,15 @@ const styles = {
 
 Image.propTypes = {
   ...ImageNative.propTypes,
+  Component: PropTypes.oneOf([
+    View,
+    TouchableOpacity,
+    TouchableHighlight,
+    TouchableNativeFeedback,
+    TouchableWithoutFeedback,
+  ]),
+  onPress: PropTypes.func,
+  onLongPress: PropTypes.func,
   ImageComponent: PropTypes.elementType,
   PlaceholderContent: nodeType,
   containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1991,6 +1991,23 @@ export class Tile extends React.Component<TileProps> {}
 
 export interface ImageProps extends RNImageProps {
   /**
+   * Component for enclosing element (eg: TouchableHighlight, View, etc)
+   *
+   * @default View
+   */
+  Component?: React.ComponentClass;
+
+  /**
+   * Callback function when pressing component
+   */
+  onPress?(): void;
+
+  /**
+   * Callback function when long pressing component
+   */
+  onLongPress?(): void;
+
+  /**
    * Specify a different component as the Image component.
    *
    * @default Image

--- a/website/docs/image.md
+++ b/website/docs/image.md
@@ -41,6 +41,8 @@ import { Image } from 'react-native-elements';
 > Contains all
 > [React Native Image](https://reactnative.dev/docs/image#methods) methods.
 
+- [`onLongPress`](#onlongpress)
+- [`onPress`](#onpress)
 - [`containerStyle`](#containerstyle)
 - [`placeholderStyle`](#placeholderstyle)
 - [`transition`](#transition)
@@ -50,6 +52,26 @@ import { Image } from 'react-native-elements';
 ---
 
 ## Reference
+
+### `onLongPress`
+
+Callback function when long pressing component
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onPress`
+
+Callback function when pressing component
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
 
 ### `containerStyle`
 


### PR DESCRIPTION
This Pull Request tries to solve the issue [816](https://github.com/react-native-elements/react-native-elements/issues/814) by following the instructions given by @flyingcircle in this [comment](https://github.com/react-native-elements/react-native-elements/issues/814#issuecomment-637161288), 

- I have added `onPress` and `onLongPress` props to `<Image />` component.
- I have also made sure that `<Component>` inside the `<Image />` component is set based on whether the user has passed either the `onPress` or `onLongPress` props or not. For inspiration, I have followed the `<Avatar />` component.
- By doing the aforementioned changes, we can make use of `imageProps` prop in `<Card />` component to pass `onPress` or `onLongPress` function props.
- Added  appropriate types in the `index.d.ts` file.
- Added documentation in the `image.md` file for `onPress` and `onLongPress` props.

Let me know if any change is required in this Pull Request or not. 

Thank You.