### PR TITLE
docs(website): Fix component preview layout

### DIFF
--- a/website/docs/badge.md
+++ b/website/docs/badge.md
@@ -6,7 +6,7 @@ title: Badge
 Badges are small components typically used to communicate a numerical value or
 indicate the status of an item to the user.
 
-<div class="component-preview">
+<div className="component-preview component-preview--grid component-preview--grid-3">
   <figure>
   <img src="/react-native-elements/img/badge/badge--standard.jpg" alt="Standard" />
     <figcaption>Standard</figcaption>

--- a/website/docs/bottomsheet.md
+++ b/website/docs/bottomsheet.md
@@ -3,7 +3,7 @@ id: bottomsheet
 title: Bottom Sheet
 ---
 
-<div class="component-preview">
+<div className="component-preview component-preview--grid component-preview--grid-3">
   <figure>
   <img src="/react-native-elements/img/bottomSheet/SimpleBottomSheet.png" alt="Simple Bottom Sheet" />
     <figcaption>Simple Bottom Sheet</figcaption>

--- a/website/docs/button.md
+++ b/website/docs/button.md
@@ -7,7 +7,7 @@ Buttons are touchable elements used to interact with the screen. They may
 display text, icons, or both. Buttons can be styled with several props to look a
 specific way.
 
-<div class="component-preview">
+<div className="component-preview component-preview--grid component-preview--grid-3">
   <figure>
     <img src="/react-native-elements/img/button/button--solid.jpg" alt="Solid Button" />
     <figcaption>Solid</figcaption>

--- a/website/docs/input.md
+++ b/website/docs/input.md
@@ -6,7 +6,7 @@ title: Input
 Inputs allow users to enter text into a UI. They typically appear in forms and
 dialogs.
 
-<div class="component-preview component-preview--2">
+<div className="component-preview component-preview--grid">
   <figure>
     <img src="/react-native-elements/img/input/input--placeholder.png" alt="Input with placeholder" />
     <figcaption>Placeholder</figcaption>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -12,6 +12,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
 import styles from '../../static/css/modules.css';
+import '../../static/css/components.css';
 
 class Button extends React.Component {
   render() {

--- a/website/static/css/components.css
+++ b/website/static/css/components.css
@@ -13,8 +13,23 @@
   grid-template-columns: 1fr 1fr;
 }
 
+@media (max-width: 400px) {
+  .component-preview--grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 600px) {
+  .component-preview--grid-3 {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.component-preview figure {
+  margin: 0;
+}
+
 .component-preview figcaption,
 .component-preview img {
   width: 100%;
 }
-

--- a/website/versioned_docs/version-2.2.1/badge.md
+++ b/website/versioned_docs/version-2.2.1/badge.md
@@ -6,7 +6,7 @@ title: Badge
 Badges are small components typically used to communicate a numerical value or
 indicate the status of an item to the user.
 
-<div class="component-preview">
+<div className="component-preview component-preview--grid component-preview--grid-3">
   <figure>
   <img src="/react-native-elements/img/badge/badge--standard.jpg" alt="Standard" />
     <figcaption>Standard</figcaption>

--- a/website/versioned_docs/version-2.2.1/bottomsheet.md
+++ b/website/versioned_docs/version-2.2.1/bottomsheet.md
@@ -3,7 +3,7 @@ id: bottomsheet
 title: Bottom Sheet
 ---
 
-<div class="component-preview">
+<div className="component-preview component-preview--grid component-preview--grid-3">
   <figure>
   <img src="/react-native-elements/img/bottomSheet/SimpleBottomSheet.png" alt="Simple Bottom Sheet" />
     <figcaption>Simple Bottom Sheet</figcaption>

--- a/website/versioned_docs/version-2.2.1/button.md
+++ b/website/versioned_docs/version-2.2.1/button.md
@@ -7,7 +7,7 @@ Buttons are touchable elements used to interact with the screen. They may
 display text, icons, or both. Buttons can be styled with several props to look a
 specific way.
 
-<div class="component-preview">
+<div className="component-preview component-preview--grid component-preview--grid-3">
   <figure>
     <img src="/react-native-elements/img/button/button--solid.jpg" alt="Solid Button" />
     <figcaption>Solid</figcaption>

--- a/website/versioned_docs/version-2.2.1/input.md
+++ b/website/versioned_docs/version-2.2.1/input.md
@@ -6,7 +6,7 @@ title: Input
 Inputs allow users to enter text into a UI. They typically appear in forms and
 dialogs.
 
-<div class="component-preview component-preview--2">
+<div className="component-preview component-preview--grid">
   <figure>
     <img src="/react-native-elements/img/input/input--placeholder.png" alt="Input with placeholder" />
     <figcaption>Placeholder</figcaption>


### PR DESCRIPTION
The new docusaurus introduced some changes that broke the layout for component previews.

This commit just aligns them again.

Quick before and after:
![Screenshot 2020-08-24 at 4 51 21 AM](https://user-images.githubusercontent.com/5962998/91024144-81f73000-e5c5-11ea-9d93-49eebb68d7be.png)


