### PR TITLE
fix styled-components with Image comp

### DIFF
--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -59,7 +59,7 @@ class Image extends React.Component {
       ...attributes
     } = this.props;
     const hasImage = Boolean(attributes.source);
-    const { width, height, ...styleProps } = style;
+    const { width, height, ...styleProps } = StyleSheet.flatten(style);
 
     return (
       <Component


### PR DESCRIPTION
Fixes: #2417

At least for `styled-components` this should be enough for fixing the `style` prop itself. However, considering other style props that get passed on, it should be considered that before unpacking, flattening the input so that it can be consistently unpacked.