### PR TITLE
Cannot access 'reverseColor' before initialization issue fixed.

### DIFF
--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -41,7 +41,7 @@ const Icon = (props) => {
     ...attributes
   } = props;
   const color = colorProp || theme.colors.black;
-  const reverseColor = reverseColor || theme.colors.white;
+  const reverseColor = reverseColorProp || theme.colors.white;
 
   const IconComponent = getIconType(type);
   const iconSpecificStyle = getIconStyle(type, { solid, brand });


### PR DESCRIPTION
fixed Icon issue, it has the wrong assignment of `reverseColor`.
whenever user try to use icon it shows can't access reverseColor before initialization error, it should be `reverseColorProp`, as `reverseColor` is destructured as `reverseColorProp`

current issue:
```
const { ...., reverseColor: reverseColorProp , ....} = props ;
const reverseColor = reverseColor || theme.colors.white;

```
issue fixed in pull request:
```
const { ... , reverseColor: reverseColorProp , ... } = props ;
const reverseColor = reverseColorProp || theme.colors.white;

```
