### PR TITLE
fix(ListItem): Avoid error when title is a React element

### DIFF
--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -89,7 +89,7 @@ const ListItem = (props) => {
     ...attributes
   } = props;
 
-  if (title && title.trim().length === 0) {
+  if (title) {
     console.warn(
       "'ListItem.title' prop has been deprecated and will be removed in the next version."
     );


### PR DESCRIPTION
As of 2.3.0 when supplying a React element to a `ListItem`s `title` prop a `title.trim is not a function` error is thrown. This PR fixes the error and allows the console warning to be shown.