### PR TITLE
fix(Image): Show placeholder when source prop exists but empty.

### DIFF
--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -58,7 +58,9 @@ class Image extends React.Component {
       children,
       ...attributes
     } = this.props;
-    const hasImage = Boolean(attributes.source);
+
+    const hasImage =
+      Boolean(attributes.source) && Boolean(attributes.source.uri);
     const { width, height, ...styleProps } = StyleSheet.flatten(style);
 
     return (


### PR DESCRIPTION
Closes #2562