### PR TITLE
chore(tooling): Uses rimraf insted of UNIX based rm -rf for removing …

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "opencollective-postinstall || exit 0",
     "lint": "eslint --ext js,ts .",
     "prettify": "prettier --single-quote --trailing-comma=es5 --write './**/*.md'",
-    "clean-install": "rm -rf node_modules && yarn"
+    "clean-install": "rimraf node_modules && yarn"
   },
   "author": "Nader Dabit & Monte Thakkar",
   "license": "MIT",
@@ -63,6 +63,7 @@
     "react-native-testing-library": "^2.1.0",
     "react-native-vector-icons": "^6.6.0",
     "react-test-renderer": "^16.13.1",
+    "rimraf": "^3.0.2",
     "typescript": "^3.9.5"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6542,7 +6542,7 @@ rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
#### Description
`rm -rf node_modules` will work only for UNIX/Linux based OS. On Windows, this will break and won't produce the required results. Therefore using rimraf for removing the node_modules will take care of the following platform discrepancies.

