### PR TITLE
Fixes issue#2414 - Tooltip - Need KeyboardAvoidingView Support for tooltip

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1503,6 +1503,11 @@ export interface TooltipProps {
    * Disable auto hiding of tooltip when touching/scrolling anywhere inside the active tooltip popover container. Tooltip closes only when overlay backdrop is pressed (or) highlighted tooltip button is pressed
    */
   closeOnlyOnBackdropPress?: boolean;
+
+  /**
+   * Flag to determine whether or not to enable keyboard avoid view.
+   */
+  withKeyboardAvoidView?: boolean;
 }
 
 export class Tooltip extends React.Component<TooltipProps, any> {

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -217,12 +217,16 @@ class Tooltip extends React.PureComponent {
   };
 
   renderStaticModalContent = () => {
-    const { withOverlay, overlayColor } = this.props;
+    const { withOverlay, overlayColor, skipAndroidStatusBar } = this.props;
 
     return (
       <Fragment>
         <TouchableOpacity
-          style={styles.container(withOverlay, overlayColor)}
+          style={styles.container(
+            withOverlay,
+            overlayColor,
+            skipAndroidStatusBar
+          )}
           onPress={this.toggleTooltip}
           activeOpacity={1}
         />
@@ -233,11 +237,15 @@ class Tooltip extends React.PureComponent {
     );
   };
   renderTogglingModalContent = () => {
-    const { withOverlay, overlayColor } = this.props;
+    const { withOverlay, overlayColor, skipAndroidStatusBar } = this.props;
 
     return (
       <TouchableOpacity
-        style={styles.container(withOverlay, overlayColor)}
+        style={styles.container(
+          withOverlay,
+          overlayColor,
+          skipAndroidStatusBar
+        )}
         onPress={this.toggleTooltip}
         activeOpacity={1}
       >
@@ -286,7 +294,7 @@ class Tooltip extends React.PureComponent {
             <KeyboardAvoidingView
               enabled={true}
               keyboardVerticalOffset={StatusBar.currentHeight}
-              behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+              behavior={Platform.OS === 'android' ? undefined : 'position'}
             >
               <ScrollView
                 scrollEnabled={false}
@@ -344,10 +352,13 @@ Tooltip.defaultProps = {
 };
 
 const styles = {
-  container: (withOverlay, overlayColor) => ({
+  container: (withOverlay, overlayColor, skipAndroidStatusBar) => ({
     backgroundColor: withOverlay ? overlayColor : 'transparent',
     width: Dimensions.get('window').width,
-    height: Dimensions.get('window').height,
+    height:
+      isIOS || skipAndroidStatusBar
+        ? Dimensions.get('window').height
+        : Dimensions.get('window').height - StatusBar.currentHeight,
   }),
   closeOnlyOnBackdropPressViewWrapper: {
     position: 'absolute',

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import {
   TouchableOpacity,
@@ -220,7 +220,7 @@ class Tooltip extends React.PureComponent {
     const { withOverlay, overlayColor, skipAndroidStatusBar } = this.props;
 
     return (
-      <View>
+      <Fragment>
         <TouchableOpacity
           style={styles.container(
             withOverlay,
@@ -233,7 +233,7 @@ class Tooltip extends React.PureComponent {
         <View style={styles.closeOnlyOnBackdropPressViewWrapper}>
           {this.renderContent(true)}
         </View>
-      </View>
+      </Fragment>
     );
   };
   renderTogglingModalContent = () => {
@@ -348,7 +348,7 @@ Tooltip.defaultProps = {
   skipAndroidStatusBar: false,
   ModalComponent: Modal,
   closeOnlyOnBackdropPress: false,
-  withKeyboardAvoidView: true,
+  withKeyboardAvoidView: false,
 };
 
 const styles = {

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -217,16 +217,12 @@ class Tooltip extends React.PureComponent {
   };
 
   renderStaticModalContent = () => {
-    const { withOverlay, overlayColor, skipAndroidStatusBar } = this.props;
+    const { withOverlay, overlayColor } = this.props;
 
     return (
       <Fragment>
         <TouchableOpacity
-          style={styles.container(
-            withOverlay,
-            overlayColor,
-            skipAndroidStatusBar
-          )}
+          style={styles.container(withOverlay, overlayColor)}
           onPress={this.toggleTooltip}
           activeOpacity={1}
         />
@@ -237,15 +233,11 @@ class Tooltip extends React.PureComponent {
     );
   };
   renderTogglingModalContent = () => {
-    const { withOverlay, overlayColor, skipAndroidStatusBar } = this.props;
+    const { withOverlay, overlayColor } = this.props;
 
     return (
       <TouchableOpacity
-        style={styles.container(
-          withOverlay,
-          overlayColor,
-          skipAndroidStatusBar
-        )}
+        style={styles.container(withOverlay, overlayColor)}
         onPress={this.toggleTooltip}
         activeOpacity={1}
       >
@@ -294,7 +286,7 @@ class Tooltip extends React.PureComponent {
             <KeyboardAvoidingView
               enabled={true}
               keyboardVerticalOffset={StatusBar.currentHeight}
-              behavior={Platform.OS === 'android' ? undefined : 'position'}
+              behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
             >
               <ScrollView
                 scrollEnabled={false}
@@ -352,13 +344,10 @@ Tooltip.defaultProps = {
 };
 
 const styles = {
-  container: (withOverlay, overlayColor, skipAndroidStatusBar) => ({
+  container: (withOverlay, overlayColor) => ({
     backgroundColor: withOverlay ? overlayColor : 'transparent',
     width: Dimensions.get('window').width,
-    height:
-      isIOS || skipAndroidStatusBar
-        ? Dimensions.get('window').height
-        : Dimensions.get('window').height - StatusBar.currentHeight,
+    height: Dimensions.get('window').height,
   }),
   closeOnlyOnBackdropPressViewWrapper: {
     position: 'absolute',

--- a/src/tooltip/__tests__/Tooltip.js
+++ b/src/tooltip/__tests__/Tooltip.js
@@ -190,4 +190,54 @@ describe('Tooltip component', () => {
     component.root.findAllByType(TouchableOpacity)[0].props.onPress();
     expect(modalComponent.props.visible).toEqual(false);
   });
+  it('should exhibhit default tooltip behaviour when "withKeyboardAvoidView" is false', () => {
+    const Info = () => <Text>Info here</Text>;
+    const component = create(
+      <Tooltip
+        height={100}
+        width={200}
+        popover={<Info />}
+        KeyboardAvoidingView={false}
+      >
+        <Text>Press me</Text>
+      </Tooltip>
+    );
+    const modalComponent = component.root.findByType(Modal);
+
+    // Check if tooltip is shown when tooltip button is pressed
+    component.root.findAllByType(TouchableOpacity)[0].props.onPress();
+    expect(modalComponent.props.visible).toEqual(true);
+    expect(component.root.findByType(Triangle)).toBeTruthy();
+    expect(component.root.findByType(Info)).toBeTruthy();
+    expect(component.toJSON()).toMatchSnapshot();
+
+    // Check if tooltip hides when touching again anywhere
+    component.root.findAllByType(TouchableOpacity)[0].props.onPress();
+    expect(modalComponent.props.visible).toEqual(false);
+  });
+  it('should enable keyboardAvoidView support for the tooltip when "withKeyboardAvoidView" is true', () => {
+    const Info = () => <Text>Info here</Text>;
+    const component = create(
+      <Tooltip
+        height={100}
+        width={200}
+        popover={<Info />}
+        KeyboardAvoidingView={true}
+      >
+        <Text>Press me</Text>
+      </Tooltip>
+    );
+    const modalComponent = component.root.findByType(Modal);
+
+    // Check if tooltip is shown when tooltip button is pressed
+    component.root.findAllByType(TouchableOpacity)[0].props.onPress();
+    expect(modalComponent.props.visible).toEqual(true);
+    expect(component.root.findByType(Triangle)).toBeTruthy();
+    expect(component.root.findByType(Info)).toBeTruthy();
+    expect(component.toJSON()).toMatchSnapshot();
+
+    // Check if tooltip hides when touching again anywhere
+    component.root.findAllByType(TouchableOpacity)[0].props.onPress();
+    expect(modalComponent.props.visible).toEqual(false);
+  });
 });

--- a/website/docs/tooltip.md
+++ b/website/docs/tooltip.md
@@ -55,6 +55,7 @@ import Modal from 'modal-react-native-web';
 - [`skipAndroidStatusBar`](#skipandroidstatusbar)
 - [`ModalComponent`](#modalcomponent)
 - [`closeOnlyOnBackdropPress`](#closeonlyonbackdroppress)
+- [`withKeyboardAvoidView`](#withkeyboardavoidview)
 
 ---
 
@@ -265,5 +266,19 @@ Flag to determine whether to disable auto hiding of tooltip when touching/scroll
 |  Type   | Default |
 | :-----: | :-----: |
 | boolean |  false  |
+
+---
+
+---
+
+### `withKeyboardAvoidView`
+
+Flag to determine whether to enable/disable rKeyboardAvoidView support for the tooltip.
+
+- When `true`, react-native's "KeyboardAvoidView" support is enabled to solve the common problem of views that need to move out of the way of the virtual keyboard
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  true   |
 
 ---


### PR DESCRIPTION
**Fixes issue#[2414](https://github.com/react-native-elements/react-native-elements/issues/2414) - Tooltip - Need KeyboardAvoidingView Support for tooltip**

- Added a configuration parameter "withKeyboardAvoidView" to the tooltip
- default value for "withKeyboardAvoidView" is false ->  keyboardAvoidView is not supported
- when set to true, KeyboardView is supported

**Working Demo :** 

![keyboardavoid](https://user-images.githubusercontent.com/30879156/93256145-320e2200-f79b-11ea-8e60-d75273844607.gif)
