### PR TITLE
Update Component default value in ButtonGroup

### DIFF
--- a/website/docs/button_group.md
+++ b/website/docs/button_group.md
@@ -144,7 +144,7 @@ Choose other button component such as TouchableOpacity (optional)
 
 |          Type          |      Default       |
 | :--------------------: | :----------------: |
-| React Native Component | TouchableHighlight |
+| React Native Component | TouchableOpacity (ios) or TouchableNativeFeedback (android) |
 
 ---
 


### PR DESCRIPTION
This change fixes the incorrect `ButtonGroup` Component prop description, copying from the `Button` component.