### PR TITLE
fix(Button): Improved UX of the LinearGradient button

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -67,14 +67,14 @@ class Button extends Component {
     } = this.props;
 
     // Refactor to Pressable
-    const TouchableComponentInternal = TouchableComponent
-      ? TouchableComponent
-      : Platform.select({
-          android: linearGradientProps
-            ? TouchableOpacity
-            : TouchableNativeFeedback,
-          default: TouchableOpacity,
-        });
+    const TouchableComponentInternal =
+      TouchableComponent ||
+      Platform.select({
+        android: linearGradientProps
+          ? TouchableOpacity
+          : TouchableNativeFeedback,
+        default: TouchableOpacity,
+      });
 
     const titleStyle = StyleSheet.flatten([
       styles.title(type, theme),

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -66,6 +66,16 @@ class Button extends Component {
       ...attributes
     } = this.props;
 
+    // Refactor to Pressable
+    const TouchableComponentInternal = TouchableComponent
+      ? TouchableComponent
+      : Platform.select({
+          android: linearGradientProps
+            ? TouchableOpacity
+            : TouchableNativeFeedback,
+          default: TouchableOpacity,
+        });
+
     const titleStyle = StyleSheet.flatten([
       styles.title(type, theme),
       passedTitleStyle,
@@ -103,7 +113,7 @@ class Button extends Component {
           raised && !disabled && styles.raised(type),
         ])}
       >
-        <TouchableComponent
+        <TouchableComponentInternal
           onPress={this.handleOnPress}
           delayPressIn={0}
           activeOpacity={0.3}
@@ -157,7 +167,7 @@ class Button extends Component {
                 ]),
               })}
           </ViewComponent>
-        </TouchableComponent>
+        </TouchableComponentInternal>
       </View>
     );
   }
@@ -190,10 +200,6 @@ Button.propTypes = {
 Button.defaultProps = {
   title: '',
   iconRight: false,
-  TouchableComponent: Platform.select({
-    android: TouchableNativeFeedback,
-    default: TouchableOpacity,
-  }),
   onPress: () => console.log('Please attach a method to this component'),
   type: 'solid',
   buttonStyle: {

--- a/src/buttons/__tests__/__snapshots__/Button.js.snap
+++ b/src/buttons/__tests__/__snapshots__/Button.js.snap
@@ -530,14 +530,7 @@ exports[`Button Component should apply values from theme 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "opacity": Object {
-          "_animation": null,
-          "_children": Array [],
-          "_listeners": Object {},
-          "_offset": 0,
-          "_startingValue": 1,
-          "_value": 1,
-        },
+        "opacity": 1,
       }
     }
   >

--- a/website/docs/button.md
+++ b/website/docs/button.md
@@ -300,9 +300,9 @@ Type of button (optional)
 
 component for user interaction
 
-|        Type         |                           Default                           |
-| :-----------------: | :---------------------------------------------------------: |
-| Touchable Component | TouchableOpacity (ios) or TouchableNativeFeedback (android) |
+|        Type         |                                                                       Default                                                                        |
+| :-----------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: |
+| Touchable Component | TouchableOpacity (ios) or TouchableNativeFeedback (android) or TouchableOpacity (android, if [`linearGradientProps`](###linearGradientProps) exists) |
 
 ---
 


### PR DESCRIPTION
Closes #2493 

If the button has linear-gradient prop then it will render `TouchableOpacity` in Android instead of `TouchableNativeFeedback` in order to provide the user with feedback.

Not using `Pressable` because of the following reasons:
- Very New.
- Needs `@latest` version of React Native, therefore won't be possible for all users to upgrade RN.
- As mentioned above, that it's very new so API may change in future to make it more stable.
