### PR TITLE
Docs: Arrange props and references alphabetically

### DIFF
--- a/website/docs/header.md
+++ b/website/docs/header.md
@@ -110,35 +110,25 @@ center, or right component's layout, you can adjust the `containerStyle`
 
 ## Props
 
-- [`containerStyle`](#containerstyle)
 - [`backgroundColor`](#backgroundcolor)
 - [`backgroundImage`](#backgroundimage)
 - [`backgroundImageStyle`](#backgroundimagestyle)
-- [`leftComponent`](#leftcomponent)
-- [`centerComponent`](#centercomponent)
-- [`rightComponent`](#rightcomponent)
-- [`leftContainerStyle`](#leftcontainerstyle)
-- [`centerContainerStyle`](#centercontainerstyle)
-- [`rightContainerStyle`](#rightcontainerstyle)
-- [`placement`](#placement)
 - [`barStyle`](#barstyle)
+- [`centerComponent`](#centercomponent)
+- [`centerContainerStyle`](#centercontainerstyle)
+- [`containerStyle`](#containerstyle)
+- [`leftComponent`](#leftcomponent)
+- [`leftContainerStyle`](#leftcontainerstyle)
+- [`linearGradientProps`](#lineargradientprops)
+- [`placement`](#placement)
+- [`rightComponent`](#rightcomponent)
+- [`rightContainerStyle`](#rightcontainerstyle)
 - [`statusBarProps`](#statusbarprops)
 - [`ViewComponent`](#viewcomponent)
-- [`linearGradientProps`](#lineargradientprops)
 
 ---
 
 ## Reference
-
-### `containerStyle`
-
-styling around the main container
-
-| Type  | Default |
-| :---: | :-----: |
-| style |  none   |
-
----
 
 ### `backgroundColor`
 
@@ -170,13 +160,13 @@ styling for backgroundImage in the main container
 
 ---
 
-### `leftComponent`
+### `barStyle`
 
-define your left component here
+Sets the color of the status bar text.
 
-|                                                                                                   Type                                                                                                    | Default |
-| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
-| { text: string, [...Text props](https://facebook.github.io/react-native/docs/text.html#props)}<br/>**OR**<br/>{ icon: string, [...Icon props](icon.md#props)} <br/>**OR**<br/> React element or component |  none   |
+|                    Type                    |                                          Default                                           |
+| :----------------------------------------: | :----------------------------------------------------------------------------------------: |
+| 'default', 'light-content', 'dark-content' | 'default' ([source](https://facebook.github.io/react-native/docs/statusbar.html#barstyle)) |
 
 ---
 
@@ -190,9 +180,29 @@ define your center component here
 
 ---
 
-### `rightComponent`
+### `centerContainerStyle`
 
-define your right component here
+styling for container around the centerComponent
+
+| Type  |   Default   |
+| :---: | :---------: |
+| style | { flex: 3 } |
+
+---
+
+### `containerStyle`
+
+styling around the main container
+
+| Type  | Default |
+| :---: | :-----: |
+| style |  none   |
+
+---
+
+### `leftComponent`
+
+define your left component here
 
 |                                                                                                   Type                                                                                                    | Default |
 | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
@@ -210,23 +220,13 @@ styling for container around the leftComponent
 
 ---
 
-### `centerContainerStyle`
+### `linearGradientProps`
 
-styling for container around the centerComponent
+displays a linear gradient. See [usage](#lineargradient-usage).
 
-| Type  |   Default   |
-| :---: | :---------: |
-| style | { flex: 3 } |
-
----
-
-### `rightContainerStyle`
-
-styling for container around the rightComponent
-
-| Type  |   Default   |
-| :---: | :---------: |
-| style | { flex: 1 } |
+|                                                      Type                                                      | Default |
+| :------------------------------------------------------------------------------------------------------------: | :-----: |
+| {[...Gradient props](https://github.com/react-native-community/react-native-linear-gradient#additional-props)} |  none   |
 
 ---
 
@@ -240,13 +240,23 @@ Alignment for title
 
 ---
 
-### `barStyle`
+### `rightComponent`
 
-Sets the color of the status bar text.
+define your right component here
 
-|                    Type                    |                                          Default                                           |
-| :----------------------------------------: | :----------------------------------------------------------------------------------------: |
-| 'default', 'light-content', 'dark-content' | 'default' ([source](https://facebook.github.io/react-native/docs/statusbar.html#barstyle)) |
+|                                                                                                   Type                                                                                                    | Default |
+| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| { text: string, [...Text props](https://facebook.github.io/react-native/docs/text.html#props)}<br/>**OR**<br/>{ icon: string, [...Icon props](icon.md#props)} <br/>**OR**<br/> React element or component |  none   |
+
+---
+
+### `rightContainerStyle`
+
+styling for container around the rightComponent
+
+| Type  |   Default   |
+| :---: | :---------: |
+| style | { flex: 1 } |
 
 ---
 
@@ -267,16 +277,6 @@ component for container
 |          Type          |     Default     |
 | :--------------------: | :-------------: |
 | React Native Component | ImageBackground |
-
----
-
-### `linearGradientProps`
-
-displays a linear gradient. See [usage](#lineargradient-usage).
-
-|                                                      Type                                                      | Default |
-| :------------------------------------------------------------------------------------------------------------: | :-----: |
-| {[...Gradient props](https://github.com/react-native-community/react-native-linear-gradient#additional-props)} |  none   |
 
 ---
 

--- a/website/docs/icon.md
+++ b/website/docs/icon.md
@@ -18,20 +18,20 @@ The icon sets in React Native Elements are made possible through
 
 The current list of available icons sets are:
 
-- [material](https://material.io/tools/icons)
-- [material-community](https://materialdesignicons.com/)
+- [antdesign](http://ant.design/components/icon/)
+- [entypo](http://www.entypo.com/)
+- [evilicon](http://evil-icons.io/)
+- [feather](https://feathericons.com/)
 - [font-awesome](https://fontawesome.com/v4.7.0/)
 - [font-awesome-5](https://fontawesome.com/)
-- [octicon](https://octicons.github.com/)
-- [ionicon](http://ionicons.com/)
+- [fontisto](https://www.fontisto.com/icons)
 - [foundation](http://zurb.com/playground/foundation-icon-fonts-3)
-- [evilicon](http://evil-icons.io/)
+- [ionicon](http://ionicons.com/)
+- [material](https://material.io/tools/icons)
+- [material-community](https://materialdesignicons.com/)
+- [octicon](https://octicons.github.com/)
 - [simple-line-icon](https://simplelineicons.github.io/)
 - [zocial](http://weloveiconfonts.com/)
-- [entypo](http://www.entypo.com/)
-- [feather](https://feathericons.com/)
-- [antdesign](http://ant.design/components/icon/)
-- [fontisto](https://www.fontisto.com/icons)
 
 ## Custom Icon Fonts
 
@@ -81,14 +81,15 @@ import { Icon } from 'react-native-elements'
 
 - [`brand`](#brand)
 - [`color`](#color)
+- [`Component`](#Component)
 - [`containerStyle`](#containerstyle)
 - [`disabled`](#disabled)
 - [`disabledStyle`](#disabledstyle)
-- [`iconStyle`](#iconstyle)
 - [`iconProps`](#iconprops)
+- [`iconStyle`](#iconstyle)
 - [`name`](#name)
-- [`onPress`](#onpress)
 - [`onLongPress`](#onlongpress)
+- [`onPress`](#onpress)
 - [`raised`](#raised)
 - [`reverse`](#reverse)
 - [`reverseColor`](#reversecolor)
@@ -96,7 +97,6 @@ import { Icon } from 'react-native-elements'
 - [`solid`](#solid)
 - [`type`](#type)
 - [`underlayColor`](#underlaycolor)
-- [`Component`](#Component)
 
 ---
 
@@ -119,6 +119,16 @@ color of icon (optional)
 |  Type  | Default |
 | :----: | :-----: |
 | string |  black  |
+
+---
+
+### `Component`
+
+update React Native Component (optional)
+
+|          Type          |                                        Default                                        |
+| :--------------------: | :-----------------------------------------------------------------------------------: |
+| React Native component | View if no onPress method is defined, TouchableHighlight if onPress method is defined |
 
 ---
 
@@ -153,16 +163,6 @@ handler.
 
 ---
 
-### `iconStyle`
-
-additional styling to icon (optional)
-
-|        Type         |     Default     |
-| :-----------------: | :-------------: |
-| View style (object) | inherited style |
-
----
-
 ### `iconProps`
 
 provide all props from react-native Icon component
@@ -170,6 +170,16 @@ provide all props from react-native Icon component
 |                                          Type                                          | Default |
 | :------------------------------------------------------------------------------------: | :-----: |
 | {[...Icon props](https://github.com/oblador/react-native-vector-icons#icon-component)} |  none   |
+
+---
+
+### `iconStyle`
+
+additional styling to icon (optional)
+
+|        Type         |     Default     |
+| :-----------------: | :-------------: |
+| View style (object) | inherited style |
 
 ---
 
@@ -183,9 +193,9 @@ name of icon (required)
 
 ---
 
-### `onPress`
+### `onLongPress`
 
-onPress method for button (optional)
+onLongPress method for button (optional)
 
 |   Type   | Default |
 | :------: | :-----: |
@@ -193,9 +203,9 @@ onPress method for button (optional)
 
 ---
 
-### `onLongPress`
+### `onPress`
 
-onLongPress method for button (optional)
+onPress method for button (optional)
 
 |   Type   | Default |
 | :------: | :-----: |
@@ -270,13 +280,3 @@ underlayColor for press event
 |  Type  |  Default   |
 | :----: | :--------: |
 | string | icon color |
-
----
-
-### `Component`
-
-update React Native Component (optional)
-
-|          Type          |                                        Default                                        |
-| :--------------------: | :-----------------------------------------------------------------------------------: |
-| React Native component | View if no onPress method is defined, TouchableHighlight if onPress method is defined |


### PR DESCRIPTION
Rearranged the props section and reference section of documentation of header and icon in an alphabetical order.
Update for #2604