### PR TITLE
Add bottom sheet containerStyle prop

### DIFF
--- a/src/bottomSheet/BottomSheet.js
+++ b/src/bottomSheet/BottomSheet.js
@@ -24,7 +24,7 @@ class BottomSheet extends Component {
 
   render() {
     const { listHeight } = this.state;
-    const { isVisible, modalProps, children } = this.props;
+    const { containerStyle, isVisible, modalProps, children } = this.props;
     const maxHeight = listHeight < MAX_HEIGHT ? listHeight : MAX_HEIGHT;
 
     return (
@@ -34,7 +34,12 @@ class BottomSheet extends Component {
         visible={isVisible}
         {...modalProps}
       >
-        <SafeAreaView style={styles.safeAreaView}>
+        <SafeAreaView
+          style={StyleSheet.flatten([
+            styles.safeAreaView,
+            containerStyle && containerStyle,
+          ])}
+        >
           <View style={styles.modalView}>
             <View
               style={([styles.listContainer], { maxHeight })}
@@ -64,6 +69,7 @@ BottomSheet.defaultProps = {
 };
 
 BottomSheet.propTypes = {
+  containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   modalProps: PropTypes.object,
   isVisible: PropTypes.bool,
 };

--- a/src/bottomSheet/__tests__/BottomSheet.js
+++ b/src/bottomSheet/__tests__/BottomSheet.js
@@ -5,6 +5,7 @@ import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme';
 
 import ListItem from '../../list/ListItem';
+import toJson from 'enzyme-to-json';
 
 /** Renders a React Component with specified layout using onLayout callback */
 const renderWithLayout = (component, layout) => {
@@ -92,5 +93,15 @@ describe('BottomSheet Component', () => {
     const layout = { width: 768, height: 400 };
     const tree = renderWithLayout(component.find(View).at(1), layout);
     expect(tree).toMatchSnapshot();
+  });
+
+  it('should render with the provided containerStyle', () => {
+    const component = shallow(
+      <BottomSheet
+        isVisible={true}
+        containerStyle={{ backgroundColor: 'rgba(1, 0.5, 0.25, 1.0)' }}
+      />
+    );
+    expect(toJson(component)).toMatchSnapshot();
   });
 });

--- a/src/bottomSheet/__tests__/__snapshots__/BottomSheet.js.snap
+++ b/src/bottomSheet/__tests__/__snapshots__/BottomSheet.js.snap
@@ -409,3 +409,41 @@ exports[`BottomSheet Component renders correctly 1`] = `
   </RCTSafeAreaView>
 </Modal>
 `;
+
+exports[`BottomSheet Component should render with the provided containerStyle 1`] = `
+<Component
+  animationType="slide"
+  hardwareAccelerated={false}
+  transparent={true}
+  visible={true}
+>
+  <ForwardRef(SafeAreaView)
+    style={
+      Object {
+        "backgroundColor": "rgba(1, 0.5, 0.25, 1.0)",
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "column-reverse",
+        }
+      }
+    >
+      <View
+        onLayout={[Function]}
+        style={
+          Object {
+            "maxHeight": 300,
+          }
+        }
+      >
+        <ScrollView />
+      </View>
+    </View>
+  </ForwardRef(SafeAreaView)>
+</Component>
+`;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -430,6 +430,12 @@ export function withBadge(
 
 export interface BottomSheetProps {
   /**
+   * Style of the bottom sheet's container
+   * Use this to change the color of the underlay
+   */
+  containerStyle?: StyleProp<ViewStyle>;
+
+  /**
    * To show or hide the Bottom Sheet Component
    * @default false
    */

--- a/website/docs/bottomsheet.md
+++ b/website/docs/bottomsheet.md
@@ -24,7 +24,10 @@ const list = [
   },
 ];
 
-<BottomSheet isVisible={isVisible}>
+<BottomSheet
+  isVisible={isVisible}
+  containerStyle={{ backgroundColor: 'rgba(0.5, 0.25, 0, 0.2)' }}
+>
   {list.map((l, i) => (
     <ListItem key={i} containerStyle={l.containerStyle} onPress={l.onPress}>
       <ListItem.Content>
@@ -39,12 +42,25 @@ const list = [
 
 ## Props
 
+- [`containerStyle`](#containerStyle)
 - [`isVisible`](#isvisible)
 - [`modalProps`](#modalprops)
 
 ---
 
 ## Reference
+
+### `containerStyle`
+
+Style of the bottom sheet's container
+
+Use this to change the color of the underlay
+
+|        Type         |    Default     |
+| :-----------------: | :------------: |
+| View style (object) | Internal Style |
+
+---
 
 ### `isVisible`
 


### PR DESCRIPTION
The bottom sheet has an underlay that currently cannot be customized. This adds the containerStyle prop that is present in other components so that style customization on the underlay is possible.