### PR TITLE
Proper style props to Button

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "logo": "https://opencollective.com/react-native-elements/logo.txt"
   },
   "dependencies": {
+    "@react-native-community/toolbar-android": "0.1.0-rc.2",
     "@types/react-native-vector-icons": "^6.4.5",
     "auto-changelog": "^2.2.1",
     "color": "^3.1.2",
@@ -68,7 +69,7 @@
     "react-dom": "16.13.1",
     "react-native": "0.63.2",
     "@testing-library/react-native": "^7.0.2",
-    "react-native-vector-icons": "^6.6.0",
+    "react-native-vector-icons": "^6.7.0",
     "react-test-renderer": "^16.13.1",
     "rimraf": "^3.0.2",
     "typescript": "^3.9.5"

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -8,6 +8,7 @@ import {
   ActivityIndicator,
   Platform,
   StyleSheet,
+  ViewPropTypes,
 } from 'react-native';
 import Color from 'color';
 
@@ -175,24 +176,24 @@ class Button extends Component {
 
 Button.propTypes = {
   title: PropTypes.string,
-  titleStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-  titleProps: PropTypes.object,
-  buttonStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  titleStyle: ViewPropTypes.style,
+  titleProps: Text.propTypes.style,
+  buttonStyle: ViewPropTypes.style,
   type: PropTypes.oneOf(['solid', 'clear', 'outline']),
   loading: PropTypes.bool,
-  loadingStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  loadingStyle: ViewPropTypes.style,
   loadingProps: PropTypes.object,
   onPress: PropTypes.func,
-  containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  containerStyle: ViewPropTypes.style,
   icon: nodeType,
-  iconContainerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  iconContainerStyle: ViewPropTypes.style,
   iconRight: PropTypes.bool,
   linearGradientProps: PropTypes.object,
   TouchableComponent: PropTypes.elementType,
   ViewComponent: PropTypes.elementType,
   disabled: PropTypes.bool,
-  disabledStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-  disabledTitleStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  disabledStyle: ViewPropTypes.style,
+  disabledTitleStyle: Text.propTypes.style,
   raised: PropTypes.bool,
   theme: PropTypes.object,
 };


### PR DESCRIPTION
Added proper style props so that when using the component we will get suggestions. 

Fixing #2659 .

```
  titleStyle: ViewPropTypes.style,
  titleProps: Text.propTypes.style,
```

![Screenshot 2020-10-31 at 2 21 37 PM](https://user-images.githubusercontent.com/35562287/97775251-3cd31980-1b85-11eb-85d1-eb286728e6a0.png)
![Screenshot 2020-10-31 at 2 22 08 PM](https://user-images.githubusercontent.com/35562287/97775252-3e044680-1b85-11eb-8397-92a39c52e390.png)

If this works we can go ahead adding it to other components.

Tests passing: 
![Screenshot 2020-10-31 at 2 28 41 PM](https://user-images.githubusercontent.com/35562287/97775279-7015a880-1b85-11eb-9b8b-b0c98b6db26f.png)

