### PR TITLE
fix(CheckBoxIcon): it always re-render even nothing change

### DIFF
--- a/src/checkbox/CheckBoxIcon.js
+++ b/src/checkbox/CheckBoxIcon.js
@@ -25,12 +25,14 @@ const CheckBoxIcon = ({
 
   const VectorIcon = iconType ? getIconType(iconType) : FAIcon;
 
+  const vectorIconStyle = { minWidth: size || 24 }
+
   return (
     <VectorIcon
       color={checked ? checkedColor : uncheckedColor}
       name={checked ? checkedIcon : uncheckedIcon}
       size={size || 24}
-      style={{ minWidth: size || 24 }}
+      style={vectorIconStyle}
       onLongPress={onLongIconPress}
       onPress={onIconPress}
     />


### PR DESCRIPTION
It perceives that `{ minWidth: size || 24 }` is different from `{ minWidth: size || 24 }` in style.
So `{ minWidth: size || 24 }`  is recognized as a new object. 
And then it always re-renders even though nothing has changed.