### PR TITLE
update header component to handle more phone shapes/sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "opencollective-postinstall": "^2.0.3",
     "prop-types": "^15.7.2",
     "react-native-ratings": "^7.3.0",
+    "react-native-safe-area-context": "^3.1.9",
     "react-native-size-matters": "^0.3.1",
     "react-native-status-bar-height": "^2.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "prop-types": "^15.7.2",
     "react-native-ratings": "^7.3.0",
     "react-native-safe-area-context": "^3.1.9",
-    "react-native-size-matters": "^0.3.1",
-    "react-native-status-bar-height": "^2.6.0"
+    "react-native-size-matters": "^0.3.1"
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "^2.0.0",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,5 +1,3 @@
-import { getStatusBarHeight } from 'react-native-status-bar-height';
-
 import BackgroundImage from './BackgroundImage';
 import colors from './colors';
 import colorsDark from './colorsDark';
@@ -11,7 +9,6 @@ export {
   BackgroundImage,
   colors,
   colorsDark,
-  getStatusBarHeight,
   fonts,
   ThemeProvider,
   ThemeConsumer,

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -87,7 +87,12 @@ class Header extends Component {
     return (
       <>
         <StatusBar barStyle={barStyle} translucent={true} {...statusBarProps} />
-        <SafeAreaView style={styles.statusBar(theme)} />
+        <SafeAreaView
+          style={StyleSheet.flatten([
+            styles.statusBar(theme),
+            backgroundColor && { backgroundColor },
+          ])}
+        />
         <ViewComponent
           testID="headerContainer"
           {...attributes}

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -185,9 +185,6 @@ Header.defaultProps = {
 };
 
 const styles = {
-  statusBar: (theme) => ({
-    backgroundColor: theme.colors.primary,
-  }),
   container: (theme) => ({
     borderBottomColor: '#f2f2f2',
     borderBottomWidth: StyleSheet.hairlineWidth,

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -8,7 +8,7 @@ import {
   ImageBackground,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { getStatusBarHeight, withTheme } from '../config';
+import { withTheme } from '../config';
 import { renderNode, nodeType, ImageSourceType } from '../helpers';
 
 import Text from '../text/Text';
@@ -85,12 +85,11 @@ class Header extends Component {
 
     return (
       <>
-        <StatusBar barStyle={barStyle} translucent={true} {...statusBarProps} />
-        <SafeAreaView
-          style={StyleSheet.flatten([
-            styles.statusBar(theme),
-            backgroundColor && { backgroundColor },
-          ])}
+        <StatusBar
+          barStyle={barStyle}
+          translucent={true}
+          backgroundColor={backgroundColor || theme.colors.primary}
+          {...statusBarProps}
         />
         <ViewComponent
           testID="headerContainer"
@@ -104,7 +103,10 @@ class Header extends Component {
           imageStyle={backgroundImageStyle}
           {...linearGradientProps}
         >
-          <SafeAreaView style={styles.headerSafeView}>
+          <SafeAreaView
+            edges={['left', 'top', 'right']}
+            style={styles.headerSafeView}
+          >
             <Children
               style={StyleSheet.flatten([
                 placement === 'center' && styles.rightLeftContainer,
@@ -184,33 +186,19 @@ Header.defaultProps = {
 
 const styles = {
   statusBar: (theme) => ({
-    flex: 0,
     backgroundColor: theme.colors.primary,
   }),
   container: (theme) => ({
     borderBottomColor: '#f2f2f2',
     borderBottomWidth: StyleSheet.hairlineWidth,
     paddingHorizontal: 10,
+    paddingVertical: 10,
     backgroundColor: theme.colors.primary,
-    paddingTop: Platform.select({
-      android: getStatusBarHeight(),
-      default: 0,
-    }),
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    height:
-      Platform.select({
-        android: 56,
-        default: 44,
-      }) +
-      Platform.select({
-        android: getStatusBarHeight(),
-        default: 0,
-      }),
   }),
   headerSafeView: {
-    flex: 1,
     flexDirection: 'row',
   },
   centerContainer: {

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -6,9 +6,8 @@ import {
   StyleSheet,
   View,
   ImageBackground,
-  SafeAreaView,
 } from 'react-native';
-
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { getStatusBarHeight, withTheme } from '../config';
 import { renderNode, nodeType, ImageSourceType } from '../helpers';
 

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   View,
   ImageBackground,
+  SafeAreaView,
 } from 'react-native';
 
 import { getStatusBarHeight, withTheme } from '../config';
@@ -84,57 +85,61 @@ class Header extends Component {
     } = this.props;
 
     return (
-      <ViewComponent
-        testID="headerContainer"
-        {...attributes}
-        style={StyleSheet.flatten([
-          styles.container(theme),
-          backgroundColor && { backgroundColor },
-          containerStyle,
-        ])}
-        source={backgroundImage}
-        imageStyle={backgroundImageStyle}
-        {...linearGradientProps}
-      >
+      <>
         <StatusBar barStyle={barStyle} translucent={true} {...statusBarProps} />
-        <Children
+        <SafeAreaView style={styles.statusBar(theme)} />
+        <ViewComponent
+          testID="headerContainer"
+          {...attributes}
           style={StyleSheet.flatten([
-            placement === 'center' && styles.rightLeftContainer,
-            leftContainerStyle,
+            styles.container(theme),
+            backgroundColor && { backgroundColor },
+            containerStyle,
           ])}
-          placement="left"
+          source={backgroundImage}
+          imageStyle={backgroundImageStyle}
+          {...linearGradientProps}
         >
-          {(React.isValidElement(children) && children) ||
-            children[0] ||
-            leftComponent}
-        </Children>
+          <SafeAreaView style={styles.headerSafeView}>
+            <Children
+              style={StyleSheet.flatten([
+                placement === 'center' && styles.rightLeftContainer,
+                leftContainerStyle,
+              ])}
+              placement="left"
+            >
+              {(React.isValidElement(children) && children) ||
+                children[0] ||
+                leftComponent}
+            </Children>
+            <Children
+              style={StyleSheet.flatten([
+                styles.centerContainer,
+                placement !== 'center' && {
+                  paddingHorizontal: Platform.select({
+                    android: 16,
+                    default: 15,
+                  }),
+                },
+                centerContainerStyle,
+              ])}
+              placement={placement}
+            >
+              {children[1] || centerComponent}
+            </Children>
 
-        <Children
-          style={StyleSheet.flatten([
-            styles.centerContainer,
-            placement !== 'center' && {
-              paddingHorizontal: Platform.select({
-                android: 16,
-                default: 15,
-              }),
-            },
-            centerContainerStyle,
-          ])}
-          placement={placement}
-        >
-          {children[1] || centerComponent}
-        </Children>
-
-        <Children
-          style={StyleSheet.flatten([
-            placement === 'center' && styles.rightLeftContainer,
-            rightContainerStyle,
-          ])}
-          placement="right"
-        >
-          {children[2] || rightComponent}
-        </Children>
-      </ViewComponent>
+            <Children
+              style={StyleSheet.flatten([
+                placement === 'center' && styles.rightLeftContainer,
+                rightContainerStyle,
+              ])}
+              placement="right"
+            >
+              {children[2] || rightComponent}
+            </Children>
+          </SafeAreaView>
+        </ViewComponent>
+      </>
     );
   }
 }
@@ -174,12 +179,19 @@ Header.defaultProps = {
 };
 
 const styles = {
+  statusBar: (theme) => ({
+    flex: 0,
+    backgroundColor: theme.colors.primary,
+  }),
   container: (theme) => ({
     borderBottomColor: '#f2f2f2',
     borderBottomWidth: StyleSheet.hairlineWidth,
     paddingHorizontal: 10,
     backgroundColor: theme.colors.primary,
-    paddingTop: getStatusBarHeight(),
+    paddingTop: Platform.select({
+      android: getStatusBarHeight(),
+      default: 0,
+    }),
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -187,8 +199,16 @@ const styles = {
       Platform.select({
         android: 56,
         default: 44,
-      }) + getStatusBarHeight(),
+      }) +
+      Platform.select({
+        android: getStatusBarHeight(),
+        default: 0,
+      }),
   }),
+  headerSafeView: {
+    flex: 1,
+    flexDirection: 'row',
+  },
   centerContainer: {
     flex: 3,
   },

--- a/src/header/__tests__/__snapshots__/Header.js.snap
+++ b/src/header/__tests__/__snapshots__/Header.js.snap
@@ -6,7 +6,7 @@ Array [
     emulateUnlessSupported={true}
     style={
       Object {
-        "backgroundColor": "#2089dc",
+        "backgroundColor": "pink",
         "flex": 0,
       }
     }

--- a/src/header/__tests__/__snapshots__/Header.js.snap
+++ b/src/header/__tests__/__snapshots__/Header.js.snap
@@ -1,29 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header Component should apply values from theme 1`] = `
-<View
-  replaceTheme={[Function]}
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "pink",
-      "borderBottomColor": "#f2f2f2",
-      "borderBottomWidth": 0.5,
-      "flexDirection": "row",
-      "height": 64,
-      "justifyContent": "space-between",
-      "paddingHorizontal": 10,
-      "paddingTop": 20,
-    }
-  }
-  testID="headerContainer"
-  updateTheme={[Function]}
->
-  <View
+Array [
+  <RCTSafeAreaView
+    emulateUnlessSupported={true}
     style={
       Object {
-        "alignItems": "flex-start",
-        "flex": 1,
+        "backgroundColor": "#2089dc",
+        "flex": 0,
+      }
+    }
+  />,
+  <View
+    replaceTheme={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "pink",
+        "borderBottomColor": "#f2f2f2",
+        "borderBottomWidth": 0.5,
+        "flexDirection": "row",
+        "height": 44,
+        "justifyContent": "space-between",
+        "paddingHorizontal": 10,
+        "paddingTop": 0,
+      }
+    }
+    testID="headerContainer"
+    updateTheme={[Function]}
+  >
+    <RCTSafeAreaView
+      emulateUnlessSupported={true}
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "flex-start",
+            "flex": 1,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 3,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flex": 1,
+          }
+        }
+      />
+    </RCTSafeAreaView>
+  </View>,
+]
+`;
+
+exports[`Header Component should render center component by passing a config through props 1`] = `
+<Fragment>
+  <StatusBar
+    animated={false}
+    showHideTransition="fade"
+    translucent={true}
+  />
+  <ForwardRef(SafeAreaView)
+    style={
+      Object {
+        "backgroundColor": "#2089dc",
+        "flex": 0,
       }
     }
   />
@@ -31,436 +86,554 @@ exports[`Header Component should apply values from theme 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "flex": 3,
+        "backgroundColor": "#2089dc",
+        "borderBottomColor": "#f2f2f2",
+        "borderBottomWidth": 0.5,
+        "flexDirection": "row",
+        "height": 44,
+        "justifyContent": "space-between",
+        "paddingHorizontal": 10,
+        "paddingTop": 0,
+      }
+    }
+    testID="headerContainer"
+  >
+    <ForwardRef(SafeAreaView)
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Children
+        placement="left"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+      <Children
+        placement="center"
+        style={
+          Object {
+            "flex": 3,
+          }
+        }
+      >
+        <Component />
+      </Children>
+      <Children
+        placement="right"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </ForwardRef(SafeAreaView)>
+  </View>
+</Fragment>
+`;
+
+exports[`Header Component should render left component by passing a component through props 1`] = `
+<Fragment>
+  <StatusBar
+    animated={false}
+    showHideTransition="fade"
+    translucent={true}
+  />
+  <ForwardRef(SafeAreaView)
+    style={
+      Object {
+        "backgroundColor": "#2089dc",
+        "flex": 0,
       }
     }
   />
   <View
     style={
       Object {
-        "alignItems": "flex-end",
-        "flex": 1,
+        "alignItems": "center",
+        "backgroundColor": "#2089dc",
+        "borderBottomColor": "#f2f2f2",
+        "borderBottomWidth": 0.5,
+        "flexDirection": "row",
+        "height": 44,
+        "justifyContent": "space-between",
+        "paddingHorizontal": 10,
+        "paddingTop": 0,
       }
     }
-  />
-</View>
-`;
-
-exports[`Header Component should render center component by passing a config through props 1`] = `
-<View
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "#2089dc",
-      "borderBottomColor": "#f2f2f2",
-      "borderBottomWidth": 0.5,
-      "flexDirection": "row",
-      "height": 64,
-      "justifyContent": "space-between",
-      "paddingHorizontal": 10,
-      "paddingTop": 20,
-    }
-  }
-  testID="headerContainer"
->
-  <StatusBar
-    animated={false}
-    showHideTransition="fade"
-    translucent={true}
-  />
-  <Children
-    placement="left"
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  />
-  <Children
-    placement="center"
-    style={
-      Object {
-        "flex": 3,
-      }
-    }
+    testID="headerContainer"
   >
-    <Component />
-  </Children>
-  <Children
-    placement="right"
-    style={
-      Object {
-        "flex": 1,
+    <ForwardRef(SafeAreaView)
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
       }
-    }
-  />
-</View>
-`;
-
-exports[`Header Component should render left component by passing a component through props 1`] = `
-<View
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "#2089dc",
-      "borderBottomColor": "#f2f2f2",
-      "borderBottomWidth": 0.5,
-      "flexDirection": "row",
-      "height": 64,
-      "justifyContent": "space-between",
-      "paddingHorizontal": 10,
-      "paddingTop": 20,
-    }
-  }
-  testID="headerContainer"
->
-  <StatusBar
-    animated={false}
-    showHideTransition="fade"
-    translucent={true}
-  />
-  <Children
-    placement="left"
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  >
-    <Button
-      onPress={[Function]}
-      title="Test button"
-    />
-  </Children>
-  <Children
-    placement="center"
-    style={
-      Object {
-        "flex": 3,
-      }
-    }
-  />
-  <Children
-    placement="right"
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  />
-</View>
+    >
+      <Children
+        placement="left"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <Button
+          onPress={[Function]}
+          title="Test button"
+        />
+      </Children>
+      <Children
+        placement="center"
+        style={
+          Object {
+            "flex": 3,
+          }
+        }
+      />
+      <Children
+        placement="right"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </ForwardRef(SafeAreaView)>
+  </View>
+</Fragment>
 `;
 
 exports[`Header Component should render left component by passing a config through props 1`] = `
-<View
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "#2089dc",
-      "borderBottomColor": "#f2f2f2",
-      "borderBottomWidth": 0.5,
-      "flexDirection": "row",
-      "height": 64,
-      "justifyContent": "space-between",
-      "paddingHorizontal": 10,
-      "paddingTop": 20,
-    }
-  }
-  testID="headerContainer"
->
+<Fragment>
   <StatusBar
     animated={false}
     showHideTransition="fade"
     translucent={true}
   />
-  <Children
-    placement="left"
+  <ForwardRef(SafeAreaView)
     style={
       Object {
-        "flex": 1,
+        "backgroundColor": "#2089dc",
+        "flex": 0,
       }
     }
+  />
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#2089dc",
+        "borderBottomColor": "#f2f2f2",
+        "borderBottomWidth": 0.5,
+        "flexDirection": "row",
+        "height": 44,
+        "justifyContent": "space-between",
+        "paddingHorizontal": 10,
+        "paddingTop": 0,
+      }
+    }
+    testID="headerContainer"
   >
-    <Component />
-  </Children>
-  <Children
-    placement="center"
-    style={
-      Object {
-        "flex": 3,
+    <ForwardRef(SafeAreaView)
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
       }
-    }
-  />
-  <Children
-    placement="right"
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  />
-</View>
+    >
+      <Children
+        placement="left"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <Component />
+      </Children>
+      <Children
+        placement="center"
+        style={
+          Object {
+            "flex": 3,
+          }
+        }
+      />
+      <Children
+        placement="right"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </ForwardRef(SafeAreaView)>
+  </View>
+</Fragment>
 `;
 
 exports[`Header Component should render right component by passing a component through props 1`] = `
-<View
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "#2089dc",
-      "borderBottomColor": "#f2f2f2",
-      "borderBottomWidth": 0.5,
-      "flexDirection": "row",
-      "height": 64,
-      "justifyContent": "space-between",
-      "paddingHorizontal": 10,
-      "paddingTop": 20,
-    }
-  }
-  testID="headerContainer"
->
+<Fragment>
   <StatusBar
     animated={false}
     showHideTransition="fade"
     translucent={true}
   />
-  <Children
-    placement="left"
+  <ForwardRef(SafeAreaView)
     style={
       Object {
-        "flex": 1,
+        "backgroundColor": "#2089dc",
+        "flex": 0,
       }
     }
   />
-  <Children
-    placement="center"
+  <View
     style={
       Object {
-        "flex": 3,
+        "alignItems": "center",
+        "backgroundColor": "#2089dc",
+        "borderBottomColor": "#f2f2f2",
+        "borderBottomWidth": 0.5,
+        "flexDirection": "row",
+        "height": 44,
+        "justifyContent": "space-between",
+        "paddingHorizontal": 10,
+        "paddingTop": 0,
       }
     }
-  />
-  <Children
-    placement="right"
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
+    testID="headerContainer"
   >
-    <Button
-      onPress={[Function]}
-      title="Test button"
-    />
-  </Children>
-</View>
+    <ForwardRef(SafeAreaView)
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Children
+        placement="left"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+      <Children
+        placement="center"
+        style={
+          Object {
+            "flex": 3,
+          }
+        }
+      />
+      <Children
+        placement="right"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <Button
+          onPress={[Function]}
+          title="Test button"
+        />
+      </Children>
+    </ForwardRef(SafeAreaView)>
+  </View>
+</Fragment>
 `;
 
 exports[`Header Component should render right component by passing a config through props 1`] = `
-<View
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "#2089dc",
-      "borderBottomColor": "#f2f2f2",
-      "borderBottomWidth": 0.5,
-      "flexDirection": "row",
-      "height": 64,
-      "justifyContent": "space-between",
-      "paddingHorizontal": 10,
-      "paddingTop": 20,
-    }
-  }
-  testID="headerContainer"
->
+<Fragment>
   <StatusBar
     animated={false}
     showHideTransition="fade"
     translucent={true}
   />
-  <Children
-    placement="left"
+  <ForwardRef(SafeAreaView)
     style={
       Object {
-        "flex": 1,
+        "backgroundColor": "#2089dc",
+        "flex": 0,
       }
     }
   />
-  <Children
-    placement="center"
+  <View
     style={
       Object {
-        "flex": 3,
+        "alignItems": "center",
+        "backgroundColor": "#2089dc",
+        "borderBottomColor": "#f2f2f2",
+        "borderBottomWidth": 0.5,
+        "flexDirection": "row",
+        "height": 44,
+        "justifyContent": "space-between",
+        "paddingHorizontal": 10,
+        "paddingTop": 0,
       }
     }
-  />
-  <Children
-    placement="right"
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
+    testID="headerContainer"
   >
-    <Component />
-  </Children>
-</View>
+    <ForwardRef(SafeAreaView)
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Children
+        placement="left"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+      <Children
+        placement="center"
+        style={
+          Object {
+            "flex": 3,
+          }
+        }
+      />
+      <Children
+        placement="right"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <Component />
+      </Children>
+    </ForwardRef(SafeAreaView)>
+  </View>
+</Fragment>
 `;
 
 exports[`Header Component should render with backgroundImage 1`] = `
-<ImageBackground
-  source={
-    Object {
-      "uri": "http://google.com",
-    }
-  }
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "#2089dc",
-      "borderBottomColor": "#f2f2f2",
-      "borderBottomWidth": 0.5,
-      "flexDirection": "row",
-      "height": 64,
-      "justifyContent": "space-between",
-      "paddingHorizontal": 10,
-      "paddingTop": 20,
-    }
-  }
-  testID="headerContainer"
->
+<Fragment>
   <StatusBar
     animated={false}
     showHideTransition="fade"
     translucent={true}
   />
-  <Children
-    placement="left"
+  <ForwardRef(SafeAreaView)
     style={
       Object {
-        "flex": 1,
+        "backgroundColor": "#2089dc",
+        "flex": 0,
       }
     }
   />
-  <Children
-    placement="center"
-    style={
+  <ImageBackground
+    source={
       Object {
-        "flex": 3,
+        "uri": "http://google.com",
       }
     }
-  />
-  <Children
-    placement="right"
     style={
       Object {
-        "flex": 1,
+        "alignItems": "center",
+        "backgroundColor": "#2089dc",
+        "borderBottomColor": "#f2f2f2",
+        "borderBottomWidth": 0.5,
+        "flexDirection": "row",
+        "height": 44,
+        "justifyContent": "space-between",
+        "paddingHorizontal": 10,
+        "paddingTop": 0,
       }
     }
-  />
-</ImageBackground>
+    testID="headerContainer"
+  >
+    <ForwardRef(SafeAreaView)
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Children
+        placement="left"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+      <Children
+        placement="center"
+        style={
+          Object {
+            "flex": 3,
+          }
+        }
+      />
+      <Children
+        placement="right"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </ForwardRef(SafeAreaView)>
+  </ImageBackground>
+</Fragment>
 `;
 
 exports[`Header Component should render with backgroundImageStyle 1`] = `
-<View
-  imageStyle={
-    Object {
-      "opacity": 0.1,
-    }
-  }
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "#2089dc",
-      "borderBottomColor": "#f2f2f2",
-      "borderBottomWidth": 0.5,
-      "flexDirection": "row",
-      "height": 64,
-      "justifyContent": "space-between",
-      "paddingHorizontal": 10,
-      "paddingTop": 20,
-    }
-  }
-  testID="headerContainer"
->
+<Fragment>
   <StatusBar
     animated={false}
     showHideTransition="fade"
     translucent={true}
   />
-  <Children
-    placement="left"
+  <ForwardRef(SafeAreaView)
     style={
       Object {
-        "flex": 1,
+        "backgroundColor": "#2089dc",
+        "flex": 0,
       }
     }
   />
-  <Children
-    placement="center"
-    style={
+  <View
+    imageStyle={
       Object {
-        "flex": 3,
+        "opacity": 0.1,
       }
     }
-  />
-  <Children
-    placement="right"
     style={
       Object {
-        "flex": 1,
+        "alignItems": "center",
+        "backgroundColor": "#2089dc",
+        "borderBottomColor": "#f2f2f2",
+        "borderBottomWidth": 0.5,
+        "flexDirection": "row",
+        "height": 44,
+        "justifyContent": "space-between",
+        "paddingHorizontal": 10,
+        "paddingTop": 0,
       }
     }
-  />
-</View>
+    testID="headerContainer"
+  >
+    <ForwardRef(SafeAreaView)
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Children
+        placement="left"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+      <Children
+        placement="center"
+        style={
+          Object {
+            "flex": 3,
+          }
+        }
+      />
+      <Children
+        placement="right"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </ForwardRef(SafeAreaView)>
+  </View>
+</Fragment>
 `;
 
 exports[`Header Component should render without issues 1`] = `
-<ImageBackground
-  source="image.png"
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "#2089dc",
-      "borderBottomColor": "#f2f2f2",
-      "borderBottomWidth": 0.5,
-      "flexDirection": "row",
-      "height": 64,
-      "justifyContent": "space-between",
-      "paddingHorizontal": 10,
-      "paddingTop": 20,
-    }
-  }
-  testID="headerContainer"
->
+<Fragment>
   <StatusBar
     animated={false}
     showHideTransition="fade"
     translucent={true}
   />
-  <Children
-    placement="left"
+  <ForwardRef(SafeAreaView)
     style={
       Object {
-        "flex": 1,
+        "backgroundColor": "#2089dc",
+        "flex": 0,
       }
     }
   />
-  <Children
-    placement="center"
+  <ImageBackground
+    source="image.png"
     style={
       Object {
-        "flex": 3,
+        "alignItems": "center",
+        "backgroundColor": "#2089dc",
+        "borderBottomColor": "#f2f2f2",
+        "borderBottomWidth": 0.5,
+        "flexDirection": "row",
+        "height": 44,
+        "justifyContent": "space-between",
+        "paddingHorizontal": 10,
+        "paddingTop": 0,
       }
     }
-  />
-  <Children
-    placement="right"
-    style={
-      Object {
-        "flex": 1,
+    testID="headerContainer"
+  >
+    <ForwardRef(SafeAreaView)
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
       }
-    }
-  />
-</ImageBackground>
+    >
+      <Children
+        placement="left"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+      <Children
+        placement="center"
+        style={
+          Object {
+            "flex": 3,
+          }
+        }
+      />
+      <Children
+        placement="right"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </ForwardRef(SafeAreaView)>
+  </ImageBackground>
+</Fragment>
 `;

--- a/src/header/__tests__/__snapshots__/Header.js.snap
+++ b/src/header/__tests__/__snapshots__/Header.js.snap
@@ -1,84 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header Component should apply values from theme 1`] = `
-Array [
+<View
+  replaceTheme={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "pink",
+      "borderBottomColor": "#f2f2f2",
+      "borderBottomWidth": 0.5,
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "paddingHorizontal": 10,
+      "paddingVertical": 10,
+    }
+  }
+  testID="headerContainer"
+  updateTheme={[Function]}
+>
   <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "pink",
-        "flex": 0,
-      }
+    edges={
+      Array [
+        "left",
+        "top",
+        "right",
+      ]
     }
-  />,
-  <View
-    replaceTheme={[Function]}
     style={
       Object {
-        "alignItems": "center",
-        "backgroundColor": "pink",
-        "borderBottomColor": "#f2f2f2",
-        "borderBottomWidth": 0.5,
         "flexDirection": "row",
-        "height": 44,
-        "justifyContent": "space-between",
-        "paddingHorizontal": 10,
-        "paddingTop": 0,
       }
     }
-    testID="headerContainer"
-    updateTheme={[Function]}
   >
-    <RNCSafeAreaView
+    <View
       style={
         Object {
+          "alignItems": "flex-start",
           "flex": 1,
-          "flexDirection": "row",
         }
       }
-    >
-      <View
-        style={
-          Object {
-            "alignItems": "flex-start",
-            "flex": 1,
-          }
+    />
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 3,
         }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 3,
-          }
+      }
+    />
+    <View
+      style={
+        Object {
+          "alignItems": "flex-end",
+          "flex": 1,
         }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "flex-end",
-            "flex": 1,
-          }
-        }
-      />
-    </RNCSafeAreaView>
-  </View>,
-]
+      }
+    />
+  </RNCSafeAreaView>
+</View>
 `;
 
 exports[`Header Component should render center component by passing a config through props 1`] = `
 <Fragment>
   <StatusBar
     animated={false}
+    backgroundColor="#2089dc"
     showHideTransition="fade"
     translucent={true}
-  />
-  <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "#2089dc",
-        "flex": 0,
-      }
-    }
   />
   <View
     style={
@@ -88,18 +76,23 @@ exports[`Header Component should render center component by passing a config thr
         "borderBottomColor": "#f2f2f2",
         "borderBottomWidth": 0.5,
         "flexDirection": "row",
-        "height": 44,
         "justifyContent": "space-between",
         "paddingHorizontal": 10,
-        "paddingTop": 0,
+        "paddingVertical": 10,
       }
     }
     testID="headerContainer"
   >
     <RNCSafeAreaView
+      edges={
+        Array [
+          "left",
+          "top",
+          "right",
+        ]
+      }
       style={
         Object {
-          "flex": 1,
           "flexDirection": "row",
         }
       }
@@ -139,16 +132,9 @@ exports[`Header Component should render left component by passing a component th
 <Fragment>
   <StatusBar
     animated={false}
+    backgroundColor="#2089dc"
     showHideTransition="fade"
     translucent={true}
-  />
-  <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "#2089dc",
-        "flex": 0,
-      }
-    }
   />
   <View
     style={
@@ -158,18 +144,23 @@ exports[`Header Component should render left component by passing a component th
         "borderBottomColor": "#f2f2f2",
         "borderBottomWidth": 0.5,
         "flexDirection": "row",
-        "height": 44,
         "justifyContent": "space-between",
         "paddingHorizontal": 10,
-        "paddingTop": 0,
+        "paddingVertical": 10,
       }
     }
     testID="headerContainer"
   >
     <RNCSafeAreaView
+      edges={
+        Array [
+          "left",
+          "top",
+          "right",
+        ]
+      }
       style={
         Object {
-          "flex": 1,
           "flexDirection": "row",
         }
       }
@@ -212,16 +203,9 @@ exports[`Header Component should render left component by passing a config throu
 <Fragment>
   <StatusBar
     animated={false}
+    backgroundColor="#2089dc"
     showHideTransition="fade"
     translucent={true}
-  />
-  <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "#2089dc",
-        "flex": 0,
-      }
-    }
   />
   <View
     style={
@@ -231,18 +215,23 @@ exports[`Header Component should render left component by passing a config throu
         "borderBottomColor": "#f2f2f2",
         "borderBottomWidth": 0.5,
         "flexDirection": "row",
-        "height": 44,
         "justifyContent": "space-between",
         "paddingHorizontal": 10,
-        "paddingTop": 0,
+        "paddingVertical": 10,
       }
     }
     testID="headerContainer"
   >
     <RNCSafeAreaView
+      edges={
+        Array [
+          "left",
+          "top",
+          "right",
+        ]
+      }
       style={
         Object {
-          "flex": 1,
           "flexDirection": "row",
         }
       }
@@ -282,16 +271,9 @@ exports[`Header Component should render right component by passing a component t
 <Fragment>
   <StatusBar
     animated={false}
+    backgroundColor="#2089dc"
     showHideTransition="fade"
     translucent={true}
-  />
-  <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "#2089dc",
-        "flex": 0,
-      }
-    }
   />
   <View
     style={
@@ -301,18 +283,23 @@ exports[`Header Component should render right component by passing a component t
         "borderBottomColor": "#f2f2f2",
         "borderBottomWidth": 0.5,
         "flexDirection": "row",
-        "height": 44,
         "justifyContent": "space-between",
         "paddingHorizontal": 10,
-        "paddingTop": 0,
+        "paddingVertical": 10,
       }
     }
     testID="headerContainer"
   >
     <RNCSafeAreaView
+      edges={
+        Array [
+          "left",
+          "top",
+          "right",
+        ]
+      }
       style={
         Object {
-          "flex": 1,
           "flexDirection": "row",
         }
       }
@@ -355,16 +342,9 @@ exports[`Header Component should render right component by passing a config thro
 <Fragment>
   <StatusBar
     animated={false}
+    backgroundColor="#2089dc"
     showHideTransition="fade"
     translucent={true}
-  />
-  <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "#2089dc",
-        "flex": 0,
-      }
-    }
   />
   <View
     style={
@@ -374,18 +354,23 @@ exports[`Header Component should render right component by passing a config thro
         "borderBottomColor": "#f2f2f2",
         "borderBottomWidth": 0.5,
         "flexDirection": "row",
-        "height": 44,
         "justifyContent": "space-between",
         "paddingHorizontal": 10,
-        "paddingTop": 0,
+        "paddingVertical": 10,
       }
     }
     testID="headerContainer"
   >
     <RNCSafeAreaView
+      edges={
+        Array [
+          "left",
+          "top",
+          "right",
+        ]
+      }
       style={
         Object {
-          "flex": 1,
           "flexDirection": "row",
         }
       }
@@ -425,16 +410,9 @@ exports[`Header Component should render with backgroundImage 1`] = `
 <Fragment>
   <StatusBar
     animated={false}
+    backgroundColor="#2089dc"
     showHideTransition="fade"
     translucent={true}
-  />
-  <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "#2089dc",
-        "flex": 0,
-      }
-    }
   />
   <ImageBackground
     source={
@@ -449,18 +427,23 @@ exports[`Header Component should render with backgroundImage 1`] = `
         "borderBottomColor": "#f2f2f2",
         "borderBottomWidth": 0.5,
         "flexDirection": "row",
-        "height": 44,
         "justifyContent": "space-between",
         "paddingHorizontal": 10,
-        "paddingTop": 0,
+        "paddingVertical": 10,
       }
     }
     testID="headerContainer"
   >
     <RNCSafeAreaView
+      edges={
+        Array [
+          "left",
+          "top",
+          "right",
+        ]
+      }
       style={
         Object {
-          "flex": 1,
           "flexDirection": "row",
         }
       }
@@ -498,16 +481,9 @@ exports[`Header Component should render with backgroundImageStyle 1`] = `
 <Fragment>
   <StatusBar
     animated={false}
+    backgroundColor="#2089dc"
     showHideTransition="fade"
     translucent={true}
-  />
-  <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "#2089dc",
-        "flex": 0,
-      }
-    }
   />
   <View
     imageStyle={
@@ -522,18 +498,23 @@ exports[`Header Component should render with backgroundImageStyle 1`] = `
         "borderBottomColor": "#f2f2f2",
         "borderBottomWidth": 0.5,
         "flexDirection": "row",
-        "height": 44,
         "justifyContent": "space-between",
         "paddingHorizontal": 10,
-        "paddingTop": 0,
+        "paddingVertical": 10,
       }
     }
     testID="headerContainer"
   >
     <RNCSafeAreaView
+      edges={
+        Array [
+          "left",
+          "top",
+          "right",
+        ]
+      }
       style={
         Object {
-          "flex": 1,
           "flexDirection": "row",
         }
       }
@@ -571,16 +552,9 @@ exports[`Header Component should render without issues 1`] = `
 <Fragment>
   <StatusBar
     animated={false}
+    backgroundColor="#2089dc"
     showHideTransition="fade"
     translucent={true}
-  />
-  <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "#2089dc",
-        "flex": 0,
-      }
-    }
   />
   <ImageBackground
     source="image.png"
@@ -591,18 +565,23 @@ exports[`Header Component should render without issues 1`] = `
         "borderBottomColor": "#f2f2f2",
         "borderBottomWidth": 0.5,
         "flexDirection": "row",
-        "height": 44,
         "justifyContent": "space-between",
         "paddingHorizontal": 10,
-        "paddingTop": 0,
+        "paddingVertical": 10,
       }
     }
     testID="headerContainer"
   >
     <RNCSafeAreaView
+      edges={
+        Array [
+          "left",
+          "top",
+          "right",
+        ]
+      }
       style={
         Object {
-          "flex": 1,
           "flexDirection": "row",
         }
       }

--- a/src/header/__tests__/__snapshots__/Header.js.snap
+++ b/src/header/__tests__/__snapshots__/Header.js.snap
@@ -2,8 +2,7 @@
 
 exports[`Header Component should apply values from theme 1`] = `
 Array [
-  <RCTSafeAreaView
-    emulateUnlessSupported={true}
+  <RNCSafeAreaView
     style={
       Object {
         "backgroundColor": "pink",
@@ -29,8 +28,7 @@ Array [
     testID="headerContainer"
     updateTheme={[Function]}
   >
-    <RCTSafeAreaView
-      emulateUnlessSupported={true}
+    <RNCSafeAreaView
       style={
         Object {
           "flex": 1,
@@ -62,7 +60,7 @@ Array [
           }
         }
       />
-    </RCTSafeAreaView>
+    </RNCSafeAreaView>
   </View>,
 ]
 `;
@@ -74,7 +72,7 @@ exports[`Header Component should render center component by passing a config thr
     showHideTransition="fade"
     translucent={true}
   />
-  <ForwardRef(SafeAreaView)
+  <RNCSafeAreaView
     style={
       Object {
         "backgroundColor": "#2089dc",
@@ -98,7 +96,7 @@ exports[`Header Component should render center component by passing a config thr
     }
     testID="headerContainer"
   >
-    <ForwardRef(SafeAreaView)
+    <RNCSafeAreaView
       style={
         Object {
           "flex": 1,
@@ -132,7 +130,7 @@ exports[`Header Component should render center component by passing a config thr
           }
         }
       />
-    </ForwardRef(SafeAreaView)>
+    </RNCSafeAreaView>
   </View>
 </Fragment>
 `;
@@ -144,7 +142,7 @@ exports[`Header Component should render left component by passing a component th
     showHideTransition="fade"
     translucent={true}
   />
-  <ForwardRef(SafeAreaView)
+  <RNCSafeAreaView
     style={
       Object {
         "backgroundColor": "#2089dc",
@@ -168,7 +166,7 @@ exports[`Header Component should render left component by passing a component th
     }
     testID="headerContainer"
   >
-    <ForwardRef(SafeAreaView)
+    <RNCSafeAreaView
       style={
         Object {
           "flex": 1,
@@ -205,7 +203,7 @@ exports[`Header Component should render left component by passing a component th
           }
         }
       />
-    </ForwardRef(SafeAreaView)>
+    </RNCSafeAreaView>
   </View>
 </Fragment>
 `;
@@ -217,7 +215,7 @@ exports[`Header Component should render left component by passing a config throu
     showHideTransition="fade"
     translucent={true}
   />
-  <ForwardRef(SafeAreaView)
+  <RNCSafeAreaView
     style={
       Object {
         "backgroundColor": "#2089dc",
@@ -241,7 +239,7 @@ exports[`Header Component should render left component by passing a config throu
     }
     testID="headerContainer"
   >
-    <ForwardRef(SafeAreaView)
+    <RNCSafeAreaView
       style={
         Object {
           "flex": 1,
@@ -275,7 +273,7 @@ exports[`Header Component should render left component by passing a config throu
           }
         }
       />
-    </ForwardRef(SafeAreaView)>
+    </RNCSafeAreaView>
   </View>
 </Fragment>
 `;
@@ -287,7 +285,7 @@ exports[`Header Component should render right component by passing a component t
     showHideTransition="fade"
     translucent={true}
   />
-  <ForwardRef(SafeAreaView)
+  <RNCSafeAreaView
     style={
       Object {
         "backgroundColor": "#2089dc",
@@ -311,7 +309,7 @@ exports[`Header Component should render right component by passing a component t
     }
     testID="headerContainer"
   >
-    <ForwardRef(SafeAreaView)
+    <RNCSafeAreaView
       style={
         Object {
           "flex": 1,
@@ -348,7 +346,7 @@ exports[`Header Component should render right component by passing a component t
           title="Test button"
         />
       </Children>
-    </ForwardRef(SafeAreaView)>
+    </RNCSafeAreaView>
   </View>
 </Fragment>
 `;
@@ -360,7 +358,7 @@ exports[`Header Component should render right component by passing a config thro
     showHideTransition="fade"
     translucent={true}
   />
-  <ForwardRef(SafeAreaView)
+  <RNCSafeAreaView
     style={
       Object {
         "backgroundColor": "#2089dc",
@@ -384,7 +382,7 @@ exports[`Header Component should render right component by passing a config thro
     }
     testID="headerContainer"
   >
-    <ForwardRef(SafeAreaView)
+    <RNCSafeAreaView
       style={
         Object {
           "flex": 1,
@@ -418,7 +416,7 @@ exports[`Header Component should render right component by passing a config thro
       >
         <Component />
       </Children>
-    </ForwardRef(SafeAreaView)>
+    </RNCSafeAreaView>
   </View>
 </Fragment>
 `;
@@ -430,7 +428,7 @@ exports[`Header Component should render with backgroundImage 1`] = `
     showHideTransition="fade"
     translucent={true}
   />
-  <ForwardRef(SafeAreaView)
+  <RNCSafeAreaView
     style={
       Object {
         "backgroundColor": "#2089dc",
@@ -459,7 +457,7 @@ exports[`Header Component should render with backgroundImage 1`] = `
     }
     testID="headerContainer"
   >
-    <ForwardRef(SafeAreaView)
+    <RNCSafeAreaView
       style={
         Object {
           "flex": 1,
@@ -491,7 +489,7 @@ exports[`Header Component should render with backgroundImage 1`] = `
           }
         }
       />
-    </ForwardRef(SafeAreaView)>
+    </RNCSafeAreaView>
   </ImageBackground>
 </Fragment>
 `;
@@ -503,7 +501,7 @@ exports[`Header Component should render with backgroundImageStyle 1`] = `
     showHideTransition="fade"
     translucent={true}
   />
-  <ForwardRef(SafeAreaView)
+  <RNCSafeAreaView
     style={
       Object {
         "backgroundColor": "#2089dc",
@@ -532,7 +530,7 @@ exports[`Header Component should render with backgroundImageStyle 1`] = `
     }
     testID="headerContainer"
   >
-    <ForwardRef(SafeAreaView)
+    <RNCSafeAreaView
       style={
         Object {
           "flex": 1,
@@ -564,7 +562,7 @@ exports[`Header Component should render with backgroundImageStyle 1`] = `
           }
         }
       />
-    </ForwardRef(SafeAreaView)>
+    </RNCSafeAreaView>
   </View>
 </Fragment>
 `;
@@ -576,7 +574,7 @@ exports[`Header Component should render without issues 1`] = `
     showHideTransition="fade"
     translucent={true}
   />
-  <ForwardRef(SafeAreaView)
+  <RNCSafeAreaView
     style={
       Object {
         "backgroundColor": "#2089dc",
@@ -601,7 +599,7 @@ exports[`Header Component should render without issues 1`] = `
     }
     testID="headerContainer"
   >
-    <ForwardRef(SafeAreaView)
+    <RNCSafeAreaView
       style={
         Object {
           "flex": 1,
@@ -633,7 +631,7 @@ exports[`Header Component should render without issues 1`] = `
           }
         }
       />
-    </ForwardRef(SafeAreaView)>
+    </RNCSafeAreaView>
   </ImageBackground>
 </Fragment>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6387,6 +6387,11 @@ react-native-ratings@^7.3.0:
     lodash "^4.17.15"
     prop-types "^15.7.2"
 
+react-native-safe-area-context@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.1.9.tgz#48864ea976b0fa57142a2cc523e1fd3314e7247e"
+  integrity sha512-wmcGbdyE/vBSL5IjDPReoJUEqxkZsywZw5gPwsVUV1NBpw5eTIdnL6Y0uNKHE25Z661moxPHQz6kwAkYQyorxA==
+
 react-native-size-matters@^0.3.1:
   version "0.3.1"
   resolved "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz#24d0cfc335a2c730f6d58bd7b43ea5a41be4b49f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6397,11 +6397,6 @@ react-native-size-matters@^0.3.1:
   resolved "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz#24d0cfc335a2c730f6d58bd7b43ea5a41be4b49f"
   integrity sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw==
 
-react-native-status-bar-height@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.npmjs.org/react-native-status-bar-height/-/react-native-status-bar-height-2.6.0.tgz#b6afd25b6e3d533c43d0fcdcfd5cafd775592cea"
-  integrity sha512-z3SGLF0mHT+OlJDq7B7h/jXPjWcdBT3V14Le5L2PjntjjWM3+EJzq2BcXDwV+v67KFNJic5pgA26cCmseYek6w==
-
 react-native-vector-icons@^7.0.0:
   version "7.1.0"
   resolved "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-7.1.0.tgz#145487d617b2a81d395d2cf64e6e065fcab3a454"


### PR DESCRIPTION
Fixes: #2704 and #1791

`Header` still needs to be outside of the `SafeAreaView`, but this integrates `SafeAreaView` into the component itself so that the left and right components have better placement in landscape orientation.