### PR TITLE
add stack-overflow icon to prop type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1676,6 +1676,7 @@ export type SocialMediaType =
   | 'twitch'
   | 'medium'
   | 'soundcloud'
+  | 'stack-overflow'
   | 'gitlab'
   | 'angellist'
   | 'codepen'

--- a/website/versioned_docs/version-3.0.0/social_icons.md
+++ b/website/versioned_docs/version-3.0.0/social_icons.md
@@ -266,7 +266,7 @@ social media type (required)
 
 |                                                                                                                                                            Type                                                                                                                                                            | Default |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
-| social media type (angellist, codepen, envelope, etsy, facebook, flickr, foursquare, github-alt, github, gitlab, instagram, linkedin, medium, pinterest, quora, reddit-alien, soundcloud, steam, stumbleupon, tumblr, twitch, twitter, google, google-plus-official, vimeo, vk, weibo, wordpress, youtube) |  none   |
+| social media type (angellist, codepen, envelope, etsy, facebook, flickr, foursquare, github-alt, github, gitlab, instagram, linkedin, medium, pinterest, quora, reddit-alien, soundcloud, stack-overflow, steam, stumbleupon, tumblr, twitch, twitter, google, google-plus-official, vimeo, vk, weibo, wordpress, youtube) |  none   |
 
 ---
 

--- a/website/versioned_docs/version-3.0.0/social_icons.md
+++ b/website/versioned_docs/version-3.0.0/social_icons.md
@@ -266,7 +266,7 @@ social media type (required)
 
 |                                                                                                                                                            Type                                                                                                                                                            | Default |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
-| social media type (angellist, codepen, envelope, etsy, facebook, flickr, foursquare, github-alt, github, gitlab, instagram, linkedin, medium, pinterest, quora, reddit-alien, soundcloud, stack-overflow, steam, stumbleupon, tumblr, twitch, twitter, google, google-plus-official, vimeo, vk, weibo, wordpress, youtube) |  none   |
+| social media type (angellist, codepen, envelope, etsy, facebook, flickr, foursquare, github-alt, github, gitlab, instagram, linkedin, medium, pinterest, quora, reddit-alien, soundcloud, steam, stumbleupon, tumblr, twitch, twitter, google, google-plus-official, vimeo, vk, weibo, wordpress, youtube) |  none   |
 
 ---
 


### PR DESCRIPTION
Removed stack-overflow type from list since it doesnt exists in TypeScript type (SocialMediaType)

Supported types: 

![image](https://user-images.githubusercontent.com/30219259/103143246-7aca6500-4712-11eb-9d88-614f8d0306c3.png)


export type SocialMediaType =
  | 'facebook'
  | 'twitter'
  | 'google-plus-official'
  | 'google'
  | 'pinterest'
  | 'linkedin'
  | 'youtube'
  | 'vimeo'
  | 'tumblr'
  | 'instagram'
  | 'quora'
  | 'flickr'
  | 'foursquare'
  | 'wordpress'
  | 'stumbleupon'
  | 'github'
  | 'github-alt'
  | 'twitch'
  | 'medium'
  | 'soundcloud'
  | 'gitlab'
  | 'angellist'
  | 'codepen'
  | 'weibo'
  | 'vk';