### PR TITLE
Expo: remove global usage due to removal in SDK 41.

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -23,7 +23,7 @@ const defaultLoadingProps = (type, theme) => ({
 class Button extends Component {
   componentDidMount() {
     const { linearGradientProps, ViewComponent } = this.props;
-    if (linearGradientProps && !global.Expo && !ViewComponent) {
+    if (linearGradientProps && !ViewComponent) {
       console.error(
         "You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}"
       );
@@ -59,9 +59,7 @@ class Button extends Component {
       disabledTitleStyle,
       raised,
       linearGradientProps,
-      ViewComponent = !disabled && linearGradientProps && global.Expo
-        ? global.Expo.LinearGradient
-        : View,
+      ViewComponent = View,
       theme,
       ...attributes
     } = this.props;

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -50,7 +50,7 @@ Children.propTypes = {
 class Header extends Component {
   componentDidMount() {
     const { linearGradientProps, ViewComponent } = this.props;
-    if (linearGradientProps && !global.Expo && !ViewComponent) {
+    if (linearGradientProps && !ViewComponent) {
       console.error(
         "You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}"
       );
@@ -74,8 +74,8 @@ class Header extends Component {
       barStyle,
       children,
       linearGradientProps,
-      ViewComponent = linearGradientProps && global.Expo
-        ? global.Expo.LinearGradient
+      ViewComponent = linearGradientProps
+        ? View
         : backgroundImage
         ? ImageBackground
         : View,

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -74,11 +74,9 @@ class Header extends Component {
       barStyle,
       children,
       linearGradientProps,
-      ViewComponent = linearGradientProps
+      ViewComponent = linearGradientProps || !backgroundImage
         ? View
-        : backgroundImage
-        ? ImageBackground
-        : View,
+        : ImageBackground,
       theme,
       ...attributes
     } = this.props;

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Platform, StyleSheet, TouchableHighlight, View } from 'react-native';
 
@@ -24,13 +24,19 @@ const ListItem = (props) => {
     topDivider,
     pad,
     linearGradientProps,
-    ViewComponent = linearGradientProps && global.Expo
-      ? global.Expo.LinearGradient
-      : View,
+    ViewComponent = View,
     theme,
     children,
     ...attributes
   } = props;
+
+  useEffect(() => {
+    if (linearGradientProps && !ViewComponent) {
+      console.error(
+        "You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}"
+      );
+    }
+  }, [linearGradientProps, ViewComponent]);
 
   return (
     <Component

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Platform, StyleSheet, TouchableHighlight, View } from 'react-native';
 
@@ -30,13 +30,11 @@ const ListItem = (props) => {
     ...attributes
   } = props;
 
-  useEffect(() => {
-    if (linearGradientProps && !ViewComponent) {
-      console.error(
-        "You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}"
-      );
-    }
-  }, [linearGradientProps, ViewComponent]);
+  if (props.linearGradientProps && !props.ViewComponent) {
+    console.error(
+      "You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}"
+    );
+  }
 
   return (
     <Component

--- a/src/list/__tests__/ListItem.js
+++ b/src/list/__tests__/ListItem.js
@@ -59,6 +59,20 @@ describe('ListItem component', () => {
     expect(toJson(component)).toMatchSnapshot();
   });
 
+  it('should warn the user when using linearGradient without it installed', () => {
+    console.error = jest.fn();
+    shallow(
+      <ListItem
+        theme={theme}
+        linearGradientProps={{ colors: ['#4c669f', '#3b5998', '#192f6a'] }}
+      />
+    );
+
+    expect(console.error.mock.calls[0][0]).toBe(
+      "You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}"
+    );
+  });
+
   it('should render with input', () => {
     const component = shallow(
       <ListItem theme={theme}>


### PR DESCRIPTION
Remove usage of global.Expo due to deprecation in SDK 40 and removal in SDK 41.

Fix #2747 