### PR TITLE
change react-native-safe-area-context to a peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "opencollective-postinstall": "^2.0.3",
     "prop-types": "^15.7.2",
     "react-native-ratings": "^7.3.0",
-    "react-native-safe-area-context": "^3.1.9",
     "react-native-size-matters": "^0.3.1"
   },
   "devDependencies": {
@@ -69,12 +68,14 @@
     "react-dom": "16.13.1",
     "react-native": "0.63.2",
     "react-native-vector-icons": "^7.0.0",
+    "react-native-safe-area-context": "^3.1.9",
     "react-test-renderer": "^16.13.1",
     "rimraf": "^3.0.2",
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
-    "react-native-vector-icons": ">7.0.0"
+    "react-native-vector-icons": ">7.0.0",
+    "react-native-safe-area-context": "^3.1.9"
   },
   "jest": {
     "preset": "react-native",

--- a/website/docs/getting_started.md
+++ b/website/docs/getting_started.md
@@ -99,3 +99,14 @@ npm i --save react-native-safe-area-context
 # link
 react-native link react-native-safe-area-context
 ```
+
+It is required to add the `SafeAreaProvider` to the outside of the app. The suggested way to do this is
+the following:
+
+```js
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+function App() {
+  return <SafeAreaProvider>...</SafeAreaProvider>;
+}
+```

--- a/website/docs/getting_started.md
+++ b/website/docs/getting_started.md
@@ -85,14 +85,17 @@ debug it using
 
 ### Step 3: Setup react-native-safe-area-context
 
-Some components such as `Header` or `BottomSheet` rely on using the **react-native-safe-area-context** library. React Native Elements already
-lists the library as dependency, but it is required to add the `SafeAreaProvider` to the outside of the app. The suggested way to do this is
-the following:
+If you have already installed **react-native-safe-area-context** as a dependency for
+your project you can skip this step. Otherwise run the following command:
 
-```js
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+> _Manual linking of react-native-safe-area-context is not necessary if you're using react-native@0.60.0 or above since it is done automatically. This will throw an error though it won't prevent the application from running. To fix this you'll simply have to run `react-native unlink react-native-safe-area-context` and the process will run as expected._
 
-function App() {
-  return <SafeAreaProvider>...</SafeAreaProvider>;
-}
+```bash
+# yarn
+yarn add react-native-safe-area-context
+# or with npm
+npm i --save react-native-safe-area-context
+
+# link
+react-native link react-native-safe-area-context
 ```


### PR DESCRIPTION
Having multiple versions of the react-native-safe-area-context causes an invariant violation when starting your app.  This fixes these two issues https://github.com/react-native-elements/react-native-elements/issues/2721 and https://github.com/react-native-elements/react-native-elements/issues/2768

I removed react-native-safe-area-context from dependencies and added it to peer and dev depencies. 