### PR TITLE
Source prop missing in Image from Accessory.jsx

### DIFF
--- a/src/avatar/Accessory.js
+++ b/src/avatar/Accessory.js
@@ -31,6 +31,7 @@ function Accessory({
       <View>
         {source ? (
           <Image
+            source={source}
             style={{
               width: size,
               height: size,


### PR DESCRIPTION
When Accessory was moved out of Avatar having a custom image as Accessory stopped working. 

See the issue https://github.com/react-native-elements/react-native-elements/issues/2787