### PR TITLE
Source prop missing in Image from Accessory.jsx

### DIFF
--- a/src/avatar/Accessory.tsx
+++ b/src/avatar/Accessory.tsx
@@ -46,6 +46,7 @@ const Accessory: React.FunctionComponent<AccessoryProps> = ({
         {source ? (
           //@ts-ignore
           <Image
+            source={source}
             style={{
               width: size,
               height: size,


### PR DESCRIPTION
When Accessory was moved out of Avatar having a custom image as Avatar stopped working. See the issue [#2787](https://github.com/react-native-elements/react-native-elements/issues/2787) 