### PR TITLE
Exported AvatarProps for the issue #2802

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,7 @@ import Image from './image/Image';
 // Productivity
 import Card from './card/Card';
 import Tile from './tile/Tile';
-import Avatar from './avatar/Avatar';
-import { AvatarProps } from './avatar/Avatar';
+import Avatar, { AvatarProps } from './avatar/Avatar';
 import Accessory from './avatar/Accessory';
 import Header from './header/Header';
 import PricingCard from './pricing/PricingCard';

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import Image from './image/Image';
 import Card from './card/Card';
 import Tile from './tile/Tile';
 import Avatar from './avatar/Avatar';
+import { AvatarProps } from './avatar/Avatar';
 import Accessory from './avatar/Accessory';
 import Header from './header/Header';
 import PricingCard from './pricing/PricingCard';
@@ -87,3 +88,4 @@ export {
   makeStyles,
   Image,
 };
+export type { AvatarProps };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,36 +3,38 @@
 // https://material.io/guidelines/components/buttons.html#buttons-raised-buttons
 // https://material.angularjs.org/latest/demo/button
 // Core
-import Button from './buttons/Button';
-import Input from './input/Input';
-import Icon from './icons/Icon';
-import ListItem from './list/ListItem';
-import SocialIcon from './social/SocialIcon';
-import Overlay from './overlay/Overlay';
+import Button, { ButtonProps } from './buttons/Button';
+import Input, { InputProps } from './input/Input';
+import Icon, { IconProps } from './icons/Icon';
+import ListItem, { ListItemProps } from './list/ListItem';
+import SocialIcon, { SocialIconProps } from './social/SocialIcon';
+import Overlay, { OverlayProps } from './overlay/Overlay';
 // Utilities
-import SearchBar from './searchbar/SearchBar';
-import Badge from './badge/Badge';
+import SearchBar, { SearchBarProps } from './searchbar/SearchBar';
+import Badge, { BadgeProps } from './badge/Badge';
 import withBadge from './badge/withBadge';
-import CheckBox from './checkbox/CheckBox';
-import Divider from './divider/Divider';
-import Slider from './slider/Slider';
-import ButtonGroup from './buttons/ButtonGroup';
-import Image from './image/Image';
+import CheckBox, { CheckBoxProps } from './checkbox/CheckBox';
+import Divider, { DividerProps } from './divider/Divider';
+import Slider, { SliderProps } from './slider/Slider';
+import ButtonGroup, { ButtonGroupProps } from './buttons/ButtonGroup';
+import Image, { ImageProps } from './image/Image';
 // Productivity
-import Card from './card/Card';
-import Tile from './tile/Tile';
+import Card, { CardProps } from './card/Card';
+import Tile, { TileProps } from './tile/Tile';
 import Avatar, { AvatarProps } from './avatar/Avatar';
-import Accessory from './avatar/Accessory';
-import Header from './header/Header';
-import PricingCard from './pricing/PricingCard';
-import Tooltip from './tooltip/Tooltip';
-import BottomSheet from './bottomSheet/BottomSheet';
+import Accessory, { AccessoryProps } from './avatar/Accessory';
+import Header, { HeaderProps } from './header/Header';
+import PricingCard, { PricingCardProps } from './pricing/PricingCard';
+import Tooltip, { TooltipProps } from './tooltip/Tooltip';
+import BottomSheet, { BottomSheetProps } from './bottomSheet/BottomSheet';
 import {
   AirbnbRating as BaseAirbnbRating,
   Rating as BaseRating,
+  RatingProps,
+  AirbnbRatingProps,
 } from 'react-native-ratings';
 // helpers
-import Text from './text/Text';
+import Text, { TextProps } from './text/Text';
 import {
   colors,
   ThemeProvider,
@@ -87,4 +89,29 @@ export {
   makeStyles,
   Image,
 };
-export type { AvatarProps };
+export type {
+  AvatarProps,
+  ButtonProps,
+  InputProps,
+  IconProps,
+  ListItemProps,
+  SocialIconProps,
+  OverlayProps,
+  SearchBarProps,
+  BadgeProps,
+  CheckBoxProps,
+  DividerProps,
+  SliderProps,
+  ButtonGroupProps,
+  ImageProps,
+  CardProps,
+  TileProps,
+  AccessoryProps,
+  HeaderProps,
+  PricingCardProps,
+  TooltipProps,
+  BottomSheetProps,
+  RatingProps,
+  AirbnbRatingProps,
+  TextProps,
+};


### PR DESCRIPTION
Exported AvatarProps from index.ts to allow importing AvatarProps from `react-native-elements` instead of `react-native-elements/dist/avatar/Avatar`