### PR TITLE
Modified the props of Icon color to incorporate PlatFormColor for issue  #2794

### DIFF
--- a/src/icons/Icon.tsx
+++ b/src/icons/Icon.tsx
@@ -37,7 +37,7 @@ export type IconType =
 
 export interface IconObject extends TouchableHighlightProps {
   name?: string;
-  color?: string;
+  color?: any;
   size?: number;
   type?: IconType;
   style?: StyleProp<TextStyle>;
@@ -91,6 +91,7 @@ const Icon: React.FunctionComponent<IconProps> = (props) => {
   const reverseColor = reverseColorProp || theme.colors.white;
   const IconComponent = getIconType(type);
   const iconSpecificStyle = getIconStyle(type, { solid, brand });
+  const isPlatformColor = typeof colorProp === 'object';
 
   const getBackgroundColor = () => {
     if (reverse) {
@@ -109,7 +110,10 @@ const Icon: React.FunctionComponent<IconProps> = (props) => {
     if (Platform.Version >= 21) {
       // @ts-ignore
       attributes.background = TouchableNativeFeedback.Ripple(
-        Color(color).alpha(0.2).rgb().string(),
+        Color(isPlatformColor ? theme.colors.black : color)
+          .alpha(0.2)
+          .rgb()
+          .string(),
         true
       );
     }

--- a/website/docs/props/rating.md
+++ b/website/docs/props/rating.md
@@ -16,6 +16,7 @@
 - [`onFinishRating`](#onfinishrating)
 - [`onStartRating`](#onstartrating)
 - [`ratingBackgroundColor`](#ratingbackgroundcolor)
+- [`tintColor`](#tintColor)
 - [`ratingColor`](#ratingcolor)
 - [`ratingCount`](#ratingcount)
 - [`ratingImage`](#ratingimage)
@@ -106,6 +107,16 @@ Callback method when the user starts the rating. (optional)
 
 Pass in a custom background-fill-color for the rating icon; use this along with
 `type='custom'` prop above (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| string (color) |  white  |
+
+---
+
+### `tintColor`
+
+Pass in a custom background-color for the rating container; (optional)
 
 |      Type      | Default |
 | :------------: | :-----: |

--- a/website/docs/props/rating.md
+++ b/website/docs/props/rating.md
@@ -16,7 +16,6 @@
 - [`onFinishRating`](#onfinishrating)
 - [`onStartRating`](#onstartrating)
 - [`ratingBackgroundColor`](#ratingbackgroundcolor)
-- [`tintColor`](#tintColor)
 - [`ratingColor`](#ratingcolor)
 - [`ratingCount`](#ratingcount)
 - [`ratingImage`](#ratingimage)
@@ -107,16 +106,6 @@ Callback method when the user starts the rating. (optional)
 
 Pass in a custom background-fill-color for the rating icon; use this along with
 `type='custom'` prop above (optional)
-
-|      Type      | Default |
-| :------------: | :-----: |
-| string (color) |  white  |
-
----
-
-### `tintColor`
-
-Pass in a custom background-color for the rating container; (optional)
 
 |      Type      | Default |
 | :------------: | :-----: |


### PR DESCRIPTION
I am a bit skeptical about my approach as I have changed the type of color prop to any.  I tried using the type `color: string | object` but that resulted in the ts error saying that **object is not assignable to string**. 

One thing I am sure of is that we need to incorporate the object as one of the types for color prop as the PlatformColor returns an object. So I thought that otherwise also we are passing object and string so assigning type any to color prop might make sense

Secondly, the TouchableNativeFeedback ripple effect takes a color as an argument whose type must be a string. Changeing that to include the object  type will require a modification in the core package so when the color is passed as PlatformColor( which is an object) we won't be able to pass that into TouchableNativeFeedback ripple effect so as a default I passed  `theme.color.black `(we can change this to any color)