### PR TITLE
fix: Make sure component is mounted before calling setState. #2751

### DIFF
--- a/src/tooltip/Tooltip.tsx
+++ b/src/tooltip/Tooltip.tsx
@@ -79,14 +79,13 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
   toggleTooltip = () => {
     const { onClose } = this.props;
     this.getElementPosition();
-    if (this._isMounted) {
+    this._isMounted &&
       this.setState((prevState) => {
         if (prevState.isVisible) {
           onClose && onClose();
         }
         return { isVisible: !prevState.isVisible };
       });
-    }
   };
 
   wrapWithPress = (
@@ -270,7 +269,7 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
           pageOffsetX,
           pageOffsetY
         ) => {
-          if (this._isMounted) {
+          this._isMounted &&
             this.setState({
               xOffset: pageOffsetX,
               yOffset:
@@ -280,7 +279,6 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
               elementWidth: width,
               elementHeight: height,
             });
-          }
         }
       );
   };

--- a/src/tooltip/Tooltip.tsx
+++ b/src/tooltip/Tooltip.tsx
@@ -79,12 +79,14 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
   toggleTooltip = () => {
     const { onClose } = this.props;
     this.getElementPosition();
-    this.setState((prevState) => {
-      if (prevState.isVisible) {
-        onClose && onClose();
-      }
-      return { isVisible: !prevState.isVisible };
-    });
+    if (this._isMounted) {
+      this.setState((prevState) => {
+        if (prevState.isVisible) {
+          onClose && onClose();
+        }
+        return { isVisible: !prevState.isVisible };
+      });
+    }
   };
 
   wrapWithPress = (
@@ -268,15 +270,17 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
           pageOffsetX,
           pageOffsetY
         ) => {
-          this.setState({
-            xOffset: pageOffsetX,
-            yOffset:
-              isIOS || skipAndroidStatusBar
-                ? pageOffsetY
-                : pageOffsetY - StatusBar.currentHeight,
-            elementWidth: width,
-            elementHeight: height,
-          });
+          if (this._isMounted) {
+            this.setState({
+              xOffset: pageOffsetX,
+              yOffset:
+                isIOS || skipAndroidStatusBar
+                  ? pageOffsetY
+                  : pageOffsetY - StatusBar.currentHeight,
+              elementWidth: width,
+              elementHeight: height,
+            });
+          }
         }
       );
   };

--- a/src/tooltip/Tooltip.tsx
+++ b/src/tooltip/Tooltip.tsx
@@ -66,7 +66,7 @@ type TooltipState = {
 
 class Tooltip extends React.Component<TooltipProps, TooltipState> {
   static defaultProps = defaultProps;
-
+  _isMounted: boolean = false;
   state = {
     isVisible: false,
     yOffset: 0,
@@ -248,8 +248,12 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
   };
 
   componentDidMount() {
+    this._isMounted = true;
     // wait to compute onLayout values.
     requestAnimationFrame(this.getElementPosition);
+  }
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   getElementPosition = () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Fixes  issue #2751 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
**If relevant, did you update the documentation?**
No
**Summary**
Added _isMounted in tooltip.tsx, set it true on componentDidMount and false on componentWillUnmount. Then added condition on setState so that it works only when the component is mounted
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
