### PR TITLE
Fixed Slider compatibility for expo web

### DIFF
--- a/src/slider/Slider.tsx
+++ b/src/slider/Slider.tsx
@@ -168,6 +168,9 @@ class Slider extends React.Component<SliderProps, SliderState> {
 
   handleMoveShouldSetPanResponder() {
     // Should we become active when the user moves a touch over the thumb?
+    if (!TRACK_STYLE) {
+      return true;
+    }
     return false;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fixed issue #2728 .
The slider component can now be used in expo-web. Earlier the slider can't move in expo web due to onMoveShouldSetPanResponder method.