### PR TITLE
fix: onClose() is executed twice when tooltip is dismissed

### DIFF
--- a/src/tooltip/Tooltip.tsx
+++ b/src/tooltip/Tooltip.tsx
@@ -334,9 +334,7 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
           animationType="fade"
           visible={isVisible}
           transparent
-          onDismiss={onClose}
           onShow={onOpen}
-          onRequestClose={onClose}
         >
           {this.renderModalContent()}
         </ModalComponent>


### PR DESCRIPTION
fixes #2855 