### PR TITLE
docs links fixes

### DIFF
--- a/website/docs/props/avatar.md
+++ b/website/docs/props/avatar.md
@@ -2,7 +2,7 @@
 
 - [`activeOpacity`](#activeopacity)
 - [`avatarStyle`](#avatarstyle)
-- [`Component`](#Component)
+- [`Component`](#component)
 - [`containerStyle`](#containerstyle)
 - [`icon`](#icon)
 - [`iconStyle`](#iconstyle)

--- a/website/docs/props/badge.md
+++ b/website/docs/props/badge.md
@@ -1,7 +1,7 @@
 ## Props
 
 - [`badgeStyle`](#badgestyle)
-- [`Component`](#Component)
+- [`Component`](#component)
 - [`containerStyle`](#containerstyle)
 - [`onPress`](#onpress)
 - [`status`](#status)

--- a/website/docs/props/button_group.md
+++ b/website/docs/props/button_group.md
@@ -7,7 +7,7 @@
 - [`buttonContainerStyle`](#buttoncontainerstyle)
 - [`buttons`](#buttons)
 - [`buttonStyle`](#buttonstyle)
-- [`Component`](#Component)
+- [`Component`](#component)
 - [`containerStyle`](#containerstyle)
 - [`disabled`](#disabled)
 - [`disabledSelectedStyle`](#disabledselectedstyle)

--- a/website/docs/props/checkbox.md
+++ b/website/docs/props/checkbox.md
@@ -5,7 +5,7 @@
 - [`checkedColor`](#checkedcolor)
 - [`checkedIcon`](#checkedicon)
 - [`checkedTitle`](#checkedtitle)
-- [`Component`](#Component)
+- [`Component`](#component)
 - [`containerStyle`](#containerstyle)
 - [`fontFamily`](#fontfamily)
 - [`iconRight`](#iconright)

--- a/website/docs/props/icon.md
+++ b/website/docs/props/icon.md
@@ -2,7 +2,7 @@
 
 - [`brand`](#brand)
 - [`color`](#color)
-- [`Component`](#Component)
+- [`Component`](#component)
 - [`containerStyle`](#containerstyle)
 - [`disabled`](#disabled)
 - [`disabledStyle`](#disabledstyle)

--- a/website/docs/props/listitem.md
+++ b/website/docs/props/listitem.md
@@ -5,7 +5,7 @@
 > props
 
 - [`bottomDivider`](#bottomdivider)
-- [`Component`](#Component)
+- [`Component`](#component)
 - [`containerStyle`](#containerstyle)
 - [`disabled`](#disabled)
 - [`disabledStyle`](#disabledstyle)

--- a/website/docs/props/social_icons.md
+++ b/website/docs/props/social_icons.md
@@ -1,7 +1,7 @@
 ## Props
 
 - [`button`](#button)
-- [`Component`](#Component)
+- [`Component`](#component)
 - [`disabled`](#disabled)
 - [`fontFamily`](#fontfamily)
 - [`fontStyle`](#fontstyle)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix

**Summary**

In Docs, many of the props markdown files had broke internal link.
They were written in a bad markdown implicit id syntax ('uppercase characters not allowed').

