### PR TITLE
bugfix: extra style prop for image children container

### DIFF
--- a/src/avatar/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/avatar/__tests__/__snapshots__/Avatar.js.snap
@@ -731,13 +731,8 @@ exports[`Avatar Component should apply values from theme 1`] = `
       />
     </View>
     <View
-      style={
-        Object {
-          "flex": 1,
-          "height": undefined,
-          "width": undefined,
-        }
-      }
+      style={Object {}}
+      testID="RNE__Image__children__container"
     />
   </View>
 </View>

--- a/src/image/Image.tsx
+++ b/src/image/Image.tsx
@@ -19,6 +19,7 @@ export type ImageProps = RNImageProps & {
   ImageComponent?: React.ComponentType<any>;
   PlaceholderContent?: React.ReactElement<any>;
   containerStyle?: StyleProp<ViewStyle>;
+  childrenContainerStyle?: StyleProp<ViewStyle>;
   placeholderStyle?: StyleProp<ViewStyle>;
   transition?: boolean;
   transitionDuration?: number;
@@ -66,6 +67,7 @@ class Image extends React.Component<
       placeholderStyle,
       PlaceholderContent,
       containerStyle,
+      childrenContainerStyle = {},
       style = {},
       ImageComponent = ImageNative,
       children,
@@ -121,7 +123,12 @@ class Image extends React.Component<
           </View>
         </Animated.View>
 
-        <View style={style}>{children}</View>
+        <View
+          testID="RNE__Image__children__container"
+          style={childrenContainerStyle}
+        >
+          {children}
+        </View>
       </Component>
     );
   }

--- a/src/image/__tests__/Image.js
+++ b/src/image/__tests__/Image.js
@@ -70,6 +70,10 @@ describe('Image Component', () => {
       <Image
         source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
         style={{ tintColor: 'red' }}
+        childrenContainerStyle={{
+          borderWidth: 1,
+          borderColor: 'red',
+        }}
       />
     );
     expect(component.find({ testID: 'RNE__Image' }).props().style).toEqual(
@@ -77,6 +81,17 @@ describe('Image Component', () => {
         tintColor: 'red',
       })
     );
+
+    expect(
+      component.find({ testID: 'RNE__Image__children__container' }).props()
+        .style
+    ).toEqual(
+      expect.objectContaining({
+        borderWidth: 1,
+        borderColor: 'red',
+      })
+    );
+
     expect(toJson(component)).toMatchSnapshot();
   });
 

--- a/src/image/__tests__/__snapshots__/Image.js.snap
+++ b/src/image/__tests__/__snapshots__/Image.js.snap
@@ -68,9 +68,11 @@ exports[`Image Component should apply value from style prop 1`] = `
   <View
     style={
       Object {
-        "tintColor": "red",
+        "borderColor": "red",
+        "borderWidth": 1,
       }
     }
+    testID="RNE__Image__children__container"
   />
 </View>
 `;
@@ -204,6 +206,7 @@ exports[`Image Component should apply values from theme 1`] = `
   </View>
   <View
     style={Object {}}
+    testID="RNE__Image__children__container"
   />
 </View>
 `;
@@ -273,6 +276,7 @@ exports[`Image Component should render without the transition 1`] = `
   </ForwardRef(AnimatedComponentWrapper)>
   <View
     style={Object {}}
+    testID="RNE__Image__children__container"
   />
 </View>
 `;

--- a/src/tile/__tests__/__snapshots__/Tile.js.snap
+++ b/src/tile/__tests__/__snapshots__/Tile.js.snap
@@ -220,17 +220,8 @@ exports[`Tile component should apply styles from theme 1`] = `
       />
     </View>
     <View
-      style={
-        Object {
-          "alignItems": "center",
-          "bottom": 0,
-          "justifyContent": "center",
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        }
-      }
+      style={Object {}}
+      testID="RNE__Image__children__container"
     >
       <View
         style={

--- a/website/docs/props/image.md
+++ b/website/docs/props/image.md
@@ -7,6 +7,7 @@
 > [React Native Image](https://reactnative.dev/docs/image#methods) methods.
 
 - [`containerStyle`](#containerstyle)
+- [`childrenContainerStyle`](#childrencontainerstyle)
 - [`ImageComponent`](#imagecomponent)
 - [`onLongPress`](#onlongpress)
 - [`onPress`](#onpress)
@@ -21,6 +22,16 @@
 ### `containerStyle`
 
 Additional styling for the container (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+### `childrenContainerStyle`
+
+Additional styling for the children container (optional)
 
 |        Type         | Default |
 | :-----------------: | :-----: |


### PR DESCRIPTION
## Motivation and solution

I solve the problem of opened issue #2581. There are no breaking changes of project and even of component 😄 
Just I've added an extra style property for ```Image``` to avoid collision between children and image styles.

Btw, I didn't expect to see an extra wrapper for children (it's redundant from my perspective) but anyway I solve the problem based on already existing functionality and expectations of constant users.

## Did you add tests for your changes?

I've extended one test case to ensure props pass correctly.

## If relevant, did you update the documentation?
Yep.

