### PR TITLE
Docs: showing the components(ShowGround).

### DIFF
--- a/website/docs/button.mdx
+++ b/website/docs/button.mdx
@@ -3,7 +3,12 @@ id: button
 title: Button
 ---
 
-import Props from './props/button.md'
+import Props from './props/button.md';
+
+import { Button, Icon } from 'react-native-elements';
+import LinearGradient from '../node_modules/react-native-web-linear-gradient';
+import ButtonShowground from './showground/ButtonShowground.mdx';
+import { ShowgroundContainer } from './showground/common/ShowgroundContainer.js';
 
 Buttons are touchable elements used to interact with the screen. They may
 display text, icons, or both. Buttons can be styled with several props to look a
@@ -15,72 +20,22 @@ specific way.
     <figcaption>Solid</figcaption>
   </figure>
   <figure>
-  <img src="/img/button/button--clear.jpg" alt="Clear Button" />
+    <img src="/img/button/button--clear.jpg" alt="Clear Button" />
     <figcaption>Clear</figcaption>
   </figure>
   <figure>
-  <img src="/img/button/button--outline.jpg" alt="Outline Button" />
+    <img src="/img/button/button--outline.jpg" alt="Outline Button" />
     <figcaption>Outline</figcaption>
   </figure>
 </div>
 
 ## Usage
 
-```js
+```js title="import"
 import { Button } from 'react-native-elements';
-import Icon from 'react-native-vector-icons/FontAwesome';
-
-<Button
-  title="Solid Button"
-/>
-
-<Button
-  title="Outline button"
-  type="outline"
-/>
-
-<Button
-  title="Clear button"
-  type="clear"
-/>
-
-<Button
-  icon={
-    <Icon
-      name="arrow-right"
-      size={15}
-      color="white"
-    />
-  }
-  title="Button with icon component"
-/>
-
-<Button
-  icon={{
-    name: "arrow-right",
-    size: 15,
-    color: "white"
-  }}
-  title="Button with icon object"
-/>
-
-<Button
-  icon={
-    <Icon
-      name="arrow-right"
-      size={15}
-      color="white"
-    />
-  }
-  iconRight
-  title="Button with right icon"
-/>
-
-<Button
-  title="Loading button"
-  loading
-/>
 ```
+
+<ButtonShowground />
 
 ---
 
@@ -99,19 +54,34 @@ For react-native-cli users, make sure to follow the
 [installation instructions](https://github.com/react-native-community/react-native-linear-gradient#add-it-to-your-project)
 and use it like this:
 
-```jsx
+<ShowgroundContainer>
+  <Button
+    ViewComponent={LinearGradient}
+    linearGradientProps={{
+      colors: ['#89216B', '#DA4453'],
+      start: { x: 0, y: 0.5 },
+      end: { x: 1, y: 0.5 },
+    }}
+    title="Linear Gradient"
+    buttonStyle={{ width: 160 }}
+  />
+</ShowgroundContainer>
+
+```js title="import"
 import { Button } from 'react-native-elements';
 import LinearGradient from 'react-native-linear-gradient';
+```
 
-...
-
+```js
 <Button
-  ViewComponent={LinearGradient} // Don't forget this!
+  ViewComponent={LinearGradient}
   linearGradientProps={{
-    colors: ['red', 'pink'],
+    colors: ['#89216B', '#DA4453'],
     start: { x: 0, y: 0.5 },
     end: { x: 1, y: 0.5 },
   }}
+  title="Linear Gradient"
+  buttonStyle={{ width: 160 }}
 />
 ```
 

--- a/website/docs/showground/ButtonShowground.mdx
+++ b/website/docs/showground/ButtonShowground.mdx
@@ -1,0 +1,147 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import { Button } from 'react-native-elements';
+import { ShowgroundContainer } from './common/ShowgroundContainer.js';
+import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
+
+### Button by types
+
+<Tabs
+  defaultValue="solid"
+  values={[
+    { label: 'Solid', value: 'solid' },
+    { label: 'Outline', value: 'outline' },
+    { label: 'Clear', value: 'clear' },
+  ]}
+>
+  <TabItem value="solid">
+    <ShowgroundContainer componentType="button">
+      <Button title="Solid Button" />
+    </ShowgroundContainer>
+
+```js
+<Button title="Solid Button" />
+```
+
+  </TabItem>
+  <TabItem value="outline">
+    <ShowgroundContainer componentType="button">
+      <Button
+        title="Outline Button"
+        type="outline"
+      />
+    </ShowgroundContainer>
+
+```js
+<Button title="Outline Button" type="outline" />
+```
+
+  </TabItem>
+  <TabItem value="clear">
+    <ShowgroundContainer componentType="button">
+      <Button title="Clear Button" type="clear"/>
+    </ShowgroundContainer>
+
+```js
+<Button title="Clear Button" type="clear" />
+```
+
+  </TabItem>
+</Tabs>
+
+### Button with icon object
+
+<ShowgroundContainer componentType="button">
+  <Button
+    icon={{
+      name: 'add',
+      size: 20,
+      color: 'white',
+    }}
+    title="Button with icon object"
+  />
+</ShowgroundContainer>
+
+```js
+<Button
+  icon={{
+    name: 'add',
+    size: 20,
+    color: 'white',
+  }}
+  title="Button with icon object"
+/>
+```
+
+### Button with right icon
+
+Add `iconRight` to show the icon on the right side of the button.
+
+<ShowgroundContainer componentType="button">
+  <Button
+    icon={{
+      name: 'add',
+      size: 20,
+      color: 'white',
+    }}
+    title="Button with right icon"
+    iconRight
+  />
+</ShowgroundContainer>
+
+```js
+<Button
+  icon={{
+    name: 'add',
+    size: 20,
+    color: 'white',
+  }}
+  title="Button with right icon"
+  iconRight
+/>
+```
+
+### Button with icon object
+
+You can use external `Icon` components inside the button.
+Example:
+
+<ShowgroundContainer componentType="button">
+  <Button
+    icon={<FontAwesomeIcon name="arrow-right" size={16} color="white" />}
+    title="Button with icon component"
+    iconRight
+    titleStyle={{ marginHorizontal: 8 }}
+  />
+</ShowgroundContainer>
+
+```js title="import"
+import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
+```
+
+```js
+<Button
+  icon={<FontAwesomeIcon name="arrow-right" size={16} color="white" />}
+  title="Button with icon component"
+  iconRight
+  titleStyle={{ marginHorizontal: 8 }}
+/>
+```
+
+### Button with loading
+
+For handling button loading add `loading` or `loading={true}` to the button. Also you can combine `loading` and `disabled`
+props to make the button unclickable.
+
+<ShowgroundContainer componentType="button">
+  <Button
+    title="Loading button"
+    buttonStyle={{ width: 150 }}
+    loading
+    disabled
+  />
+</ShowgroundContainer>
+
+```js
+<Button title="Loading button" buttonStyle={{ width: 150 }} loading disabled />
+```

--- a/website/docs/showground/common/ShowgroundContainer.js
+++ b/website/docs/showground/common/ShowgroundContainer.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import '../../../static/css/showground.css';
+
+export const ShowgroundContainer = ({ children, ...props }) => {
+  return (
+    <div className={`showground component-${props.componentType}`}>
+      {children}
+    </div>
+  );
+};

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -18,11 +18,12 @@ module.exports = {
   scripts: ['https://buttons.github.io/buttons.js'],
   plugins: [
     [
-    '@docusaurus/plugin-client-redirects',
+      '@docusaurus/plugin-client-redirects',
       {
         fromExtensions: ['html'],
       },
-    ]
+    ],
+    'docs-plugin-react-native-elements-web',
   ],
   presets: [
     [
@@ -32,13 +33,14 @@ module.exports = {
           homePageId: 'getting_started',
           path: 'docs',
           sidebarPath: require.resolve('./sidebars.json'),
-          editUrl: 'https://github.com/react-native-elements/react-native-elements/edit/next/website/'
+          editUrl:
+            'https://github.com/react-native-elements/react-native-elements/edit/next/website/',
         },
         theme: {
           customCss: require.resolve('./static/css/custom.css'),
-        }
-      }
-    ]
+        },
+      },
+    ],
   ],
   themeConfig: {
     sidebarCollapsible: false,
@@ -46,20 +48,21 @@ module.exports = {
       title: 'React Native Elements',
       logo: {
         alt: 'React Native Elements Logo',
-        src: 'img/logo-icon.svg'
+        src: 'img/logo-icon.svg',
       },
       items: [
         { to: 'docs/', label: 'Docs', position: 'right' },
         { to: 'docs/overview', label: 'Components', position: 'right' },
         { to: 'help', label: 'Help', position: 'right' },
         {
-          href: 'https://github.com/react-native-elements/react-native-elements',
+          href:
+            'https://github.com/react-native-elements/react-native-elements',
           label: 'GitHub',
-          position: 'right'
+          position: 'right',
         },
         { to: 'blog', label: 'Blog', position: 'right' },
-        { to: 'versions', label: 'Versions'}
-      ]
+        { to: 'versions', label: 'Versions' },
+      ],
     },
     algolia: {
       apiKey: '89e04a9445d16350e100c2d2421f2d39',
@@ -71,7 +74,7 @@ module.exports = {
     footer: {
       style: 'dark',
       logo: {
-        src: 'img/logo.png'
+        src: 'img/logo.png',
       },
       links: [
         {
@@ -79,41 +82,43 @@ module.exports = {
           items: [
             {
               label: 'Getting Started',
-              to: 'docs/'
+              to: 'docs/',
             },
             {
               label: 'Components',
-              to: 'docs/overview'
-            }
-          ]
+              to: 'docs/overview',
+            },
+          ],
         },
         {
           title: 'Community',
           items: [
             {
               label: 'Chat with us on Slack',
-              to: 'https://react-native-elements-slack.herokuapp.com/'
+              to: 'https://react-native-elements-slack.herokuapp.com/',
             },
             {
               label: 'Submit a bug or feature',
-              to: 'https://github.com/react-native-elements/react-native-elements/issues/'
+              to:
+                'https://github.com/react-native-elements/react-native-elements/issues/',
             },
             {
               label: 'Support us on Open Collective',
-              to: 'https://opencollective.com/react-native-elements'
-            }
-          ]
+              to: 'https://opencollective.com/react-native-elements',
+            },
+          ],
         },
         {
           title: 'More',
           items: [
             {
               label: 'GitHub',
-              to: 'https://github.com/react-native-elements/react-native-elements'
-            }
-          ]
-        }
-      ]
-    }
-  }
+              to:
+                'https://github.com/react-native-elements/react-native-elements',
+            },
+          ],
+        },
+      ],
+    },
+  },
 };

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.13.0",
-    "babel-loader": "^8.2.2"
+    "babel-loader": "^8.2.2",
+    "file-loader": "^6.2.0"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -16,8 +16,17 @@
     "@docusaurus/plugin-client-redirects": "^2.0.0-alpha.69",
     "@docusaurus/plugin-google-analytics": "^2.0.0-alpha.69",
     "@docusaurus/preset-classic": "^2.0.0-alpha.69",
+    "docs-plugin-react-native-elements-web": "./plugins/web-support-plugin",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "react-native-elements": "^3.3.2",
+    "react-native-vector-icons": "^8.1.0",
+    "react-native-web": "^0.15.6",
+    "react-native-web-linear-gradient": "^1.1.1"
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.13.0",
+    "babel-loader": "^8.2.2"
   }
 }

--- a/website/plugins/web-support-plugin/package.json
+++ b/website/plugins/web-support-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs-plugin-react-native-elements-web",
+  "description": "A local Docusaurus plugin to show react-native-elements components in the document.",
+  "version": "1.0.0",
+  "main": "src/index.js"
+}

--- a/website/plugins/web-support-plugin/src/index.js
+++ b/website/plugins/web-support-plugin/src/index.js
@@ -9,6 +9,14 @@ module.exports = function () {
         module: {
           rules: [
             {
+              test: /\.(ttf)$/i,
+              use: [
+                {
+                  loader: 'file-loader',
+                },
+              ],
+            },
+            {
               test: /\.m?js$/,
               use: [
                 getBabelLoader(isServer, {

--- a/website/plugins/web-support-plugin/src/index.js
+++ b/website/plugins/web-support-plugin/src/index.js
@@ -1,0 +1,57 @@
+const path = require('path');
+
+module.exports = function () {
+  return {
+    name: 'docs-plugin-react-native-elements-web',
+    configureWebpack(config, isServer, utils) {
+      const { getBabelLoader } = utils;
+      return {
+        module: {
+          rules: [
+            {
+              test: /\.m?js$/,
+              use: [
+                getBabelLoader(isServer, {
+                  plugins: ['@babel/plugin-proposal-class-properties'],
+                  presets: ['@babel/preset-react'],
+                }),
+              ],
+              include: [
+                path.join(
+                  __dirname,
+                  '..',
+                  '..',
+                  '..',
+                  'node_modules',
+                  'react-native-elements'
+                ),
+                path.resolve(
+                  __dirname,
+                  '..',
+                  '..',
+                  '..',
+                  'node_modules',
+                  'react-native-vector-icons'
+                ),
+                path.resolve(
+                  __dirname,
+                  '..',
+                  '..',
+                  '..',
+                  'node_modules',
+                  'react-native-ratings'
+                ),
+              ],
+            },
+          ],
+        },
+        resolve: {
+          alias: {
+            'react-native$': 'react-native-web',
+            'react-native-linear-gradient': 'react-native-web-linear-gradient',
+          },
+        },
+      };
+    },
+  };
+};

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,5 +1,21 @@
 /* your custom css */
 
+@font-face {
+  font-family: 'MaterialIcons';
+  src: url('~react-native-vector-icons/Fonts/MaterialIcons.ttf')
+    format('truetype');
+}
+@font-face {
+  font-family: 'FontAwesome';
+  src: url('~react-native-vector-icons/Fonts/FontAwesome.ttf')
+    format('truetype');
+}
+@font-face {
+  font-family: 'MaterialCommunityIcons';
+  src: url('~react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf')
+    format('truetype');
+}
+
 :root {
   --ifm-color-primary: #2089dc;
   --ifm-color-primary-dark: #1d7bc6;
@@ -13,7 +29,7 @@
   --ifm-hero-text-color: #fff;
 }
 
-:root[data-theme="dark"] {
+:root[data-theme='dark'] {
   --ifm-color-primary: #60ace8;
   --ifm-color-primary-dark: #439de4;
   --ifm-color-primary-darker: #3596e2;
@@ -39,7 +55,7 @@
   background-color: #b60205;
 }
 .label.help {
-  background-color: #128A0C;
+  background-color: #128a0c;
 }
 .label.question {
   background-color: #cc317c;
@@ -55,10 +71,10 @@
   background-color: #0052cc;
 }
 .label.first {
-  background-color: #464EBA;
+  background-color: #464eba;
 }
 .label.fixed {
-  background-color: #CEE3CE;
+  background-color: #cee3ce;
   color: #000;
 }
 .label.response {

--- a/website/static/css/showground.css
+++ b/website/static/css/showground.css
@@ -1,0 +1,15 @@
+.showground {
+  border: var(--ifm-table-border-width) solid var(--ifm-table-border-color);
+  border-radius: 4px;
+  padding: var(--ifm-table-cell-padding);
+  margin-bottom: var(--ifm-leading);
+  width: 100%;
+  min-height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.showground.component-button {
+  min-height: 120px;
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Main goal is splitting "Usage" codes and showing them with actual RN Elements components. 

-Added a docusaurus plugin to show React Native Elements components in the documentation.

-Made changes on the Button component firstly, to show usage.

i can update other components too if you like it. 

![Screenshot (450)](https://user-images.githubusercontent.com/22915881/114412860-2ad6b780-9bb6-11eb-81d9-82e27db182b7.png)

![Screenshot (451)](https://user-images.githubusercontent.com/22915881/114413546-bfd9b080-9bb6-11eb-9c96-d8757745259f.png)

