### PR TITLE
Fixed incompatible changes in Image component.

### DIFF
--- a/src/avatar/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/avatar/__tests__/__snapshots__/Avatar.js.snap
@@ -731,7 +731,13 @@ exports[`Avatar Component should apply values from theme 1`] = `
       />
     </View>
     <View
-      style={Object {}}
+      style={
+        Object {
+          "flex": 1,
+          "height": undefined,
+          "width": undefined,
+        }
+      }
       testID="RNE__Image__children__container"
     />
   </View>

--- a/src/image/Image.tsx
+++ b/src/image/Image.tsx
@@ -67,7 +67,7 @@ class Image extends React.Component<
       placeholderStyle,
       PlaceholderContent,
       containerStyle,
-      childrenContainerStyle = {},
+      childrenContainerStyle = null,
       style = {},
       ImageComponent = ImageNative,
       children,
@@ -125,7 +125,7 @@ class Image extends React.Component<
 
         <View
           testID="RNE__Image__children__container"
-          style={childrenContainerStyle}
+          style={childrenContainerStyle ?? style}
         >
           {children}
         </View>

--- a/src/image/__tests__/Image.js
+++ b/src/image/__tests__/Image.js
@@ -70,6 +70,21 @@ describe('Image Component', () => {
       <Image
         source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
         style={{ tintColor: 'red' }}
+      />
+    );
+    expect(component.find({ testID: 'RNE__Image' }).props().style).toEqual(
+      expect.objectContaining({
+        tintColor: 'red',
+      })
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should apply value from childrenContainerStyle prop', () => {
+    const component = shallow(
+      <Image
+        source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }}
+        style={{ tintColor: 'red' }}
         childrenContainerStyle={{
           borderWidth: 1,
           borderColor: 'red',

--- a/src/image/__tests__/__snapshots__/Image.js.snap
+++ b/src/image/__tests__/__snapshots__/Image.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Image Component should apply value from style prop 1`] = `
+exports[`Image Component should apply value from childrenContainerStyle prop 1`] = `
 <View
   accessibilityIgnoresInvertColors={true}
   style={
@@ -70,6 +70,82 @@ exports[`Image Component should apply value from style prop 1`] = `
       Object {
         "borderColor": "red",
         "borderWidth": 1,
+      }
+    }
+    testID="RNE__Image__children__container"
+  />
+</View>
+`;
+
+exports[`Image Component should apply value from style prop 1`] = `
+<View
+  accessibilityIgnoresInvertColors={true}
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "overflow": "hidden",
+      "position": "relative",
+    }
+  }
+>
+  <Image
+    onLoad={[Function]}
+    source={
+      Object {
+        "uri": "https://i.imgur.com/0y8Ftya.jpg",
+      }
+    }
+    style={
+      Object {
+        "bottom": 0,
+        "height": undefined,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "tintColor": "red",
+        "top": 0,
+        "width": undefined,
+      }
+    }
+    testID="RNE__Image"
+    transition={true}
+    transitionDuration={360}
+  />
+  <ForwardRef(AnimatedComponentWrapper)
+    accessibilityElementsHidden={true}
+    importantForAccessibility="no-hide-descendants"
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {
+          "opacity": 1,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#bdbdbd",
+          "justifyContent": "center",
+          "tintColor": "red",
+        }
+      }
+      testID="RNE__Image__placeholder"
+    />
+  </ForwardRef(AnimatedComponentWrapper)>
+  <View
+    style={
+      Object {
+        "tintColor": "red",
       }
     }
     testID="RNE__Image__children__container"

--- a/src/tile/__tests__/__snapshots__/Tile.js.snap
+++ b/src/tile/__tests__/__snapshots__/Tile.js.snap
@@ -220,7 +220,17 @@ exports[`Tile component should apply styles from theme 1`] = `
       />
     </View>
     <View
-      style={Object {}}
+      style={
+        Object {
+          "alignItems": "center",
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
       testID="RNE__Image__children__container"
     >
       <View


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Fixed #2992 

**Did you add tests for your changes?**

Added test when not using `childrenContainerStyle` props.



Snapshot was updated in https://github.com/react-native-elements/react-native-elements/pull/2933 , but when I didn't use `childrenContainerStyle` props, I returned Snapshot to same result as `3.3.2`.

**If relevant, did you update the documentation?**

No update required.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

I wrote the reason in #2992 .

I thought I would use `childrenContainerStyle` instead of `style` for `View` component style only when `childrenContainerStyle` props was specified.

If `3.4.0` behaves correctly and I think it's a bug, please close this pull request.

（If you make a mistake in using `childrenContainerStyle` props, it would be helpful if you could tell me.）

**Does this PR introduce a breaking change?**
 
Result may be different from the `style` when displayed with `Image` component of `3.4.0` .

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
