### PR TITLE
Add accessibility props + test to LinearProgress, Tab, Switch & Slider

### DIFF
--- a/src/linearProgress/LinearProgress.tsx
+++ b/src/linearProgress/LinearProgress.tsx
@@ -70,6 +70,13 @@ const LinearProgress: RneFunctionComponent<LinearProgressProps> = ({
 
   return (
     <View
+      accessible
+      accessibilityRole="progressbar"
+      accessibilityValue={{
+        now: value,
+        min: 0,
+        max: 1,
+      }}
       {...props}
       onLayout={(e) => {
         setWidth(e.nativeEvent.layout.width);

--- a/src/linearProgress/__tests__/LinearProgress.tsx
+++ b/src/linearProgress/__tests__/LinearProgress.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import LinearProgress from '../LinearProgress';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import { render } from '@testing-library/react-native';
 import theme from '../../config/theme';
 
 describe('LinearProgress Component', () => {
@@ -37,5 +38,17 @@ describe('LinearProgress Component', () => {
     );
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should contain the required accessibility properties', () => {
+    const component = render(<LinearProgress value={0.4} />);
+    const progressBar = component.getByA11yRole('progressbar');
+    expect(progressBar.props).toMatchObject({
+      accessibilityValue: {
+        now: 0.4,
+        min: 0,
+        max: 1,
+      },
+    });
   });
 });

--- a/src/linearProgress/__tests__/__snapshots__/LinearProgress.tsx.snap
+++ b/src/linearProgress/__tests__/__snapshots__/LinearProgress.tsx.snap
@@ -2,6 +2,15 @@
 
 exports[`LinearProgress Component should render determinant without issues 1`] = `
 <View
+  accessibilityRole="progressbar"
+  accessibilityValue={
+    Object {
+      "max": 1,
+      "min": 0,
+      "now": 0.4,
+    }
+  }
+  accessible={true}
   onLayout={[Function]}
   style={
     Array [
@@ -36,6 +45,15 @@ exports[`LinearProgress Component should render determinant without issues 1`] =
 
 exports[`LinearProgress Component should render indeterminant without issues 1`] = `
 <View
+  accessibilityRole="progressbar"
+  accessibilityValue={
+    Object {
+      "max": 1,
+      "min": 0,
+      "now": 0,
+    }
+  }
+  accessible={true}
   onLayout={[Function]}
   style={
     Array [
@@ -70,6 +88,15 @@ exports[`LinearProgress Component should render indeterminant without issues 1`]
 
 exports[`LinearProgress Component should render without issues 1`] = `
 <View
+  accessibilityRole="progressbar"
+  accessibilityValue={
+    Object {
+      "max": 1,
+      "min": 0,
+      "now": 0,
+    }
+  }
+  accessible={true}
   onLayout={[Function]}
   style={
     Array [

--- a/src/slider/Slider.tsx
+++ b/src/slider/Slider.tsx
@@ -479,6 +479,12 @@ const Slider: RneFunctionComponent<SliderProps> = (props) => {
         style,
       ])}
       onLayout={measureContainer}
+      accessibilityRole="adjustable"
+      accessibilityValue={{
+        min: minimumValue,
+        max: maximumValue,
+        now: props.value,
+      }}
     >
       <View
         style={StyleSheet.flatten([

--- a/src/slider/__tests__/Slider.tsx
+++ b/src/slider/__tests__/Slider.tsx
@@ -4,6 +4,7 @@ import toJson from 'enzyme-to-json';
 import { create } from 'react-test-renderer';
 import { ThemeProvider } from '../../config';
 import ThemedSlider, { Slider } from '../Slider';
+import { render } from '@testing-library/react-native';
 
 describe('Slider component', () => {
   it('should render without issues', () => {
@@ -82,5 +83,17 @@ describe('Slider component', () => {
       backgroundColor: 'blue',
     });
     expect(component.toJSON).toMatchSnapshot();
+  });
+
+  it('should contain the required accessibility props', () => {
+    const component = render(
+      <Slider value={15} maximumValue={10} minimumValue={5} />
+    );
+    const slider = component.getByA11yRole('adjustable');
+    expect(slider.props.accessibilityValue).toMatchObject({
+      min: 5,
+      max: 10,
+      now: 15,
+    });
   });
 });

--- a/src/slider/__tests__/__snapshots__/Slider.tsx.snap
+++ b/src/slider/__tests__/__snapshots__/Slider.tsx.snap
@@ -4,6 +4,14 @@ exports[`Slider component should apply values from theme 1`] = `[Function]`;
 
 exports[`Slider component should bound the max value 1`] = `
 <View
+  accessibilityRole="adjustable"
+  accessibilityValue={
+    Object {
+      "max": 10,
+      "min": 5,
+      "now": 15,
+    }
+  }
   allowTouchTrack={false}
   animationType="timing"
   onLayout={[Function]}
@@ -81,6 +89,14 @@ exports[`Slider component should bound the max value 1`] = `
 
 exports[`Slider component should bound the min value 1`] = `
 <View
+  accessibilityRole="adjustable"
+  accessibilityValue={
+    Object {
+      "max": 10,
+      "min": 5,
+      "now": 2,
+    }
+  }
   allowTouchTrack={false}
   animationType="timing"
   onLayout={[Function]}
@@ -158,6 +174,14 @@ exports[`Slider component should bound the min value 1`] = `
 
 exports[`Slider component should pass down Thumb transform values 1`] = `
 <View
+  accessibilityRole="adjustable"
+  accessibilityValue={
+    Object {
+      "max": 1,
+      "min": 0,
+      "now": 0,
+    }
+  }
   allowTouchTrack={false}
   animationType="timing"
   onLayout={[Function]}
@@ -244,6 +268,14 @@ exports[`Slider component should pass down Thumb transform values 1`] = `
 
 exports[`Slider component should render vertically 1`] = `
 <View
+  accessibilityRole="adjustable"
+  accessibilityValue={
+    Object {
+      "max": 1,
+      "min": 0,
+      "now": 0,
+    }
+  }
   allowTouchTrack={false}
   animationType="timing"
   onLayout={[Function]}
@@ -324,6 +356,14 @@ exports[`Slider component should render vertically 1`] = `
 
 exports[`Slider component should render with ThumbTouchRect 1`] = `
 <View
+  accessibilityRole="adjustable"
+  accessibilityValue={
+    Object {
+      "max": 100,
+      "min": 0,
+      "now": 0,
+    }
+  }
   allowTouchTrack={false}
   animationType="timing"
   onLayout={[Function]}
@@ -414,6 +454,14 @@ exports[`Slider component should render with ThumbTouchRect 1`] = `
 
 exports[`Slider component should render without issues 1`] = `
 <View
+  accessibilityRole="adjustable"
+  accessibilityValue={
+    Object {
+      "max": 1,
+      "min": 0,
+      "now": 0,
+    }
+  }
   allowTouchTrack={false}
   animationType="timing"
   onLayout={[Function]}

--- a/src/switch/__tests__/Switch.tsx
+++ b/src/switch/__tests__/Switch.tsx
@@ -4,6 +4,7 @@ import { Switch } from '../switch';
 import theme from '../../config/theme';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import { render } from '@testing-library/react-native';
 
 describe('Switch Component', () => {
   it('should render without issues', () => {
@@ -115,5 +116,21 @@ describe('Switch Component', () => {
       />
     );
     expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should contain the required accessibility properties', () => {
+    const enabledComponent = render(<Switch value />);
+    const enabledSwitch = enabledComponent.getByA11yRole('switch');
+    expect(enabledSwitch.props.accessibilityState).toMatchObject({
+      checked: true,
+      disabled: false,
+    });
+
+    const disabledComponent = render(<Switch value={false} disabled />);
+    const disabledSwitch = disabledComponent.getByA11yRole('switch');
+    expect(disabledSwitch.props.accessibilityState).toMatchObject({
+      checked: false,
+      disabled: true,
+    });
   });
 });

--- a/src/switch/__tests__/__snapshots__/Switch.tsx.snap
+++ b/src/switch/__tests__/__snapshots__/Switch.tsx.snap
@@ -2,6 +2,12 @@
 
 exports[`Switch Component renders with props on ios 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
   disabled={false}
   trackColor={
     Object {
@@ -15,6 +21,12 @@ exports[`Switch Component renders with props on ios 1`] = `
 
 exports[`Switch Component renders with style prop 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
   disabled={false}
   style={
     Object {
@@ -33,6 +45,12 @@ exports[`Switch Component renders with style prop 1`] = `
 
 exports[`Switch Component renders without style prop 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
   disabled={false}
   trackColor={
     Object {
@@ -46,6 +64,12 @@ exports[`Switch Component renders without style prop 1`] = `
 
 exports[`Switch Component should have an onValueChange event 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": true,
+    }
+  }
   disabled={true}
   trackColor={
     Object {
@@ -59,6 +83,12 @@ exports[`Switch Component should have an onValueChange event 1`] = `
 
 exports[`Switch Component should render determinant without issues 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": false,
+      "disabled": true,
+    }
+  }
   disabled={true}
   trackColor={
     Object {
@@ -72,6 +102,12 @@ exports[`Switch Component should render determinant without issues 1`] = `
 
 exports[`Switch Component should render indeterminant without issues 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
   disabled={false}
   trackColor={
     Object {
@@ -85,6 +121,12 @@ exports[`Switch Component should render indeterminant without issues 1`] = `
 
 exports[`Switch Component should render with disabled false 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
   disabled={false}
   trackColor={
     Object {
@@ -98,6 +140,12 @@ exports[`Switch Component should render with disabled false 1`] = `
 
 exports[`Switch Component should render with disabled true 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": true,
+    }
+  }
   disabled={true}
   trackColor={
     Object {
@@ -111,6 +159,12 @@ exports[`Switch Component should render with disabled true 1`] = `
 
 exports[`Switch Component should render with props on android with disabled true 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": true,
+    }
+  }
   disabled={true}
   thumbColor="hsl(208, 8%, 90%)"
   trackColor={
@@ -125,6 +179,12 @@ exports[`Switch Component should render with props on android with disabled true
 
 exports[`Switch Component should render with props on web 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
   activeThumbColor="#2089dc"
   activeTrackColor="#2089dc"
   disabled={false}
@@ -136,6 +196,12 @@ exports[`Switch Component should render with props on web 1`] = `
 
 exports[`Switch Component should render with value 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
   disabled={false}
   trackColor={
     Object {
@@ -149,6 +215,12 @@ exports[`Switch Component should render with value 1`] = `
 
 exports[`Switch Component should render without disabled 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
   disabled={false}
   trackColor={
     Object {
@@ -162,6 +234,12 @@ exports[`Switch Component should render without disabled 1`] = `
 
 exports[`Switch Component should render without issues 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
   disabled={false}
   trackColor={
     Object {
@@ -175,6 +253,12 @@ exports[`Switch Component should render without issues 1`] = `
 
 exports[`Switch Component should render without value 1`] = `
 <Switch
+  accessibilityState={
+    Object {
+      "checked": false,
+      "disabled": false,
+    }
+  }
   disabled={false}
   trackColor={
     Object {

--- a/src/switch/switch.tsx
+++ b/src/switch/switch.tsx
@@ -61,6 +61,10 @@ const Switch: RneFunctionComponent<SwitchProps> = ({
   return (
     <NativeSwitch
       value={value}
+      accessibilityState={{
+        checked: value,
+        disabled,
+      }}
       disabled={disabled}
       onValueChange={disabled ? undefined : onValueChange}
       style={style}

--- a/src/tab/__tests__/__snapshots__/tab.tsx.snap
+++ b/src/tab/__tests__/__snapshots__/tab.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Tab Component should render without issues 1`] = `
 <Fragment>
   <View
+    accessibilityRole="tablist"
     onLayout={[Function]}
     style={
       Array [

--- a/src/tab/__tests__/tab.tsx
+++ b/src/tab/__tests__/tab.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { Tab } from '../tab';
 import theme from '../../config/theme';
+import { render } from '@testing-library/react-native';
 
 describe('Tab Component', () => {
   beforeEach(() => {
@@ -22,5 +23,25 @@ describe('Tab Component', () => {
     );
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should contain the required accessibility properties', () => {
+    const items = ['Tab 1', 'Tab 2', 'Tab 3'];
+    const component = render(
+      <Tab variant="default">
+        {items.map((i) => (
+          <Tab.Item key={i} title={i} />
+        ))}
+      </Tab>
+    );
+    const tabContainer = component.getByA11yRole('tablist');
+    expect(tabContainer).toBeDefined();
+
+    const tabs = component.getAllByA11yRole('tab');
+    expect(tabs.length).toBe(items.length);
+    tabs.forEach((tab) => {
+      expect(tab.props.accessibilityState.selected).toBe(false);
+      expect(items.includes(tab.props.accessibilityValue.text)).toBe(true);
+    });
   });
 });

--- a/src/tab/tab.tsx
+++ b/src/tab/tab.tsx
@@ -25,10 +25,16 @@ const TabItem: RneFunctionComponent<TabItemProps> = ({
   buttonStyle,
   variant,
   iconPosition = 'top',
+  title,
   ...props
 }) => {
   return (
     <Button
+      accessibilityRole="tab"
+      accessibilityState={{ selected: active }}
+      accessibilityValue={
+        typeof title === 'string' ? { text: title } : undefined
+      }
       buttonStyle={[styles.buttonStyle, buttonStyle]}
       titleStyle={[
         styles.titleStyle,
@@ -88,6 +94,7 @@ const TabContainer: RneFunctionComponent<TabProps> = ({
     <>
       <View
         {...props}
+        accessibilityRole="tablist"
         style={[
           styles.viewStyle,
           variant === 'primary' && {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

I noticed that LinearProgress had 0 accessibility props set. I added all relevant props for indicating progress to VoiceOver/TalkBack

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

No

**Summary**

Tested by setting these props directly in my app against existing LinearProgress component.

**Does this PR introduce a breaking change?**

No