### PR TITLE
Fix typo

### DIFF
--- a/website/docs/listitem.md
+++ b/website/docs/listitem.md
@@ -284,12 +284,12 @@ import LinearGradient from 'react-native-linear-gradient'; // Only if no expo
 </ListItem.Accordion>
 ```
 
-### ListItem Swipable
+### ListItem Swipeable
 
 <img src="/img/swipeable.gif" width="500" />
 
 ```js
-<ListItem.Swipable
+<ListItem.Swipeable
   leftContent={
     <Button
       title="Info"
@@ -310,7 +310,7 @@ import LinearGradient from 'react-native-linear-gradient'; // Only if no expo
     <ListItem.Title>Hello Swiper</ListItem.Title>
   </ListItem.Content>
   <ListItem.Chevron />
-</ListItem.Swipable>
+</ListItem.Swipeable>
 ```
 
 ---

--- a/website/docs/props/listitem.md
+++ b/website/docs/props/listitem.md
@@ -59,7 +59,7 @@
 
 > Also Receives all [ListItem](#props) props.
 
-### ListItem.Swipable
+### ListItem.Swipeable
 
 > Also recieves all `ListItem` Props
 

--- a/website/versioned_docs/version-3.4.2/listitem.md
+++ b/website/versioned_docs/version-3.4.2/listitem.md
@@ -284,12 +284,12 @@ import LinearGradient from 'react-native-linear-gradient'; // Only if no expo
 </ListItem.Accordion>
 ```
 
-### ListItem Swipable
+### ListItem Swipeable
 
 <img src="/img/swipeable.gif" width="500" />
 
 ```js
-<ListItem.Swipable
+<ListItem.Swipeable
   leftContent={
     <Button
       title="Info"
@@ -310,7 +310,7 @@ import LinearGradient from 'react-native-linear-gradient'; // Only if no expo
     <ListItem.Title>Hello Swiper</ListItem.Title>
   </ListItem.Content>
   <ListItem.Chevron />
-</ListItem.Swipable>
+</ListItem.Swipeable>
 ```
 
 ---

--- a/website/versioned_docs/version-3.4.2/props/listitem.md
+++ b/website/versioned_docs/version-3.4.2/props/listitem.md
@@ -59,7 +59,7 @@
 
 > Also Receives all [ListItem](#props) props.
 
-### ListItem.Swipable
+### ListItem.Swipeable
 
 > Also recieves all `ListItem` Props
 


### PR DESCRIPTION
The documentation consistently but wrongly names "ListItem.Swip**e**able" "ListItem.Swipable", and therefore has caused me far too much sweat today... This PR fixes this.