### PR TITLE
[BottomSheet] Add scrollViewProps to BottomSheet Component

### DIFF
--- a/src/BottomSheet/BottomSheet.tsx
+++ b/src/BottomSheet/BottomSheet.tsx
@@ -7,6 +7,7 @@ import {
   StyleProp,
   ViewStyle,
   ModalProps,
+  ScrollViewProps,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { RneFunctionComponent } from '../helpers';
@@ -15,6 +16,7 @@ export type BottomSheetProps = {
   containerStyle?: StyleProp<ViewStyle>;
   modalProps?: ModalProps;
   isVisible?: boolean;
+  scrollViewProps?: ScrollViewProps;
 };
 
 export const BottomSheet: RneFunctionComponent<BottomSheetProps> = ({
@@ -22,6 +24,7 @@ export const BottomSheet: RneFunctionComponent<BottomSheetProps> = ({
   isVisible = false,
   modalProps = {},
   children,
+  scrollViewProps = {},
   ...props
 }) => {
   return (
@@ -39,7 +42,7 @@ export const BottomSheet: RneFunctionComponent<BottomSheetProps> = ({
         {...props}
       >
         <View>
-          <ScrollView>{children}</ScrollView>
+          <ScrollView {...scrollViewProps}>{children}</ScrollView>
         </View>
       </SafeAreaView>
     </Modal>

--- a/src/BottomSheet/__tests__/BottomSheet.tsx
+++ b/src/BottomSheet/__tests__/BottomSheet.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BottomSheet } from '../index';
-import { Modal } from 'react-native';
+import { Modal, ScrollView } from 'react-native';
 import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme';
 import ListItem from '../../ListItem/index';
@@ -65,5 +65,17 @@ describe('BottomSheet Component', () => {
       />
     );
     expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render ScrollView with the provided scrollViewProps', () => {
+    const component = shallow(
+      <BottomSheet
+        isVisible={true}
+        scrollViewProps={{ keyboardShouldPersistTaps: 'handled' }}
+      />
+    );
+    expect(component.find(ScrollView).props().keyboardShouldPersistTaps).toBe(
+      'handled'
+    );
   });
 });

--- a/website/docs/main/props/bottomsheet.md
+++ b/website/docs/main/props/bottomsheet.md
@@ -37,3 +37,13 @@ Additional props handed to the `Modal`
 |                             Type                             | Default |
 | :----------------------------------------------------------: | :-----: |
 | [Modal Props](https://reactnative.dev/docs/modal.html#props) |   {}    |
+
+---
+
+### `scrollViewProps`
+
+Additional props handed to the `ScrollView`
+
+|                               Type                                | Default |
+| :---------------------------------------------------------------: | :-----: |
+| [ScrollView Props](https://reactnative.dev/docs/scrollview#props) |   {}    |


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Add scrollViewProps to BottomSheet Component

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

Yes

**Summary**

I am using a library where if it's placed inside a ScrollView, the ScrollView's keyboardShouldPersistTaps props should be set to 'handled'

Close #3110

**Does this PR introduce a breaking change?**

No
