### PR TITLE
allowTouchTrack prop is not working issue (#3130) fixed

### DIFF
--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -306,7 +306,7 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
     if (!allowTouchTrack && !TRACK_STYLE) {
       return thumbHitTest(e);
     }
-    if (!trackStyle) {
+    if (!trackStyle && allowTouchTrack) {
       setCurrentValue(getOnTouchValue(e));
     }
     fireChangeEvent('onValueChange');


### PR DESCRIPTION
Open issue  - #3130 Fixed

There is a bug in slider component props called allowTouchTrack, according to 
docs, allowTouchTrack props default value is false but it behave like that the value is 
true , even if you set the value to true it just make no change to behaviour.

I simply solve this bug by just adding one more condition in ' if ' condition.

After applying changes , i did some test of my own and it work fine.


