### PR TITLE
Added support for screen orientation

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -216,6 +216,7 @@ class Tooltip extends React.PureComponent {
           onDismiss={onClose}
           onShow={onOpen}
           onRequestClose={onClose}
+          supportedOrientations={['portrait', 'portrait-upside-down', 'landscape', 'landscape-left', 'landscape-right']}
         >
           <TouchableOpacity
             style={styles.container(withOverlay, overlayColor)}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

 a bugfix

**Did you add tests for your changes?**

**If relevant, did you update the documentation?**

**Summary**
Previously, the modal component specification changed the orientation of the phone screen when the tooltip was opened.
Screen orientation doesn't change with added support for screen orientation.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
I will attach an image.
I'm not good at English, so maybe I'm doing something wrong.
If so, I'm sorry.

## Before this change
![Tooltip-before](https://user-images.githubusercontent.com/84759670/125667242-0ca782d1-42b3-4d45-8d77-49a7be51cdab.GIF)
## After this change
![Tooltip-after](https://user-images.githubusercontent.com/84759670/125667264-d65fc0de-4b89-4dc7-89e9-01ea90d10c06.GIF)
