### PR TITLE
Fix: Issue #3066 SocialIcon: Overall icon size doesn't change when prop raised={true}

### DIFF
--- a/src/SocialIcon/SocialIcon.tsx
+++ b/src/SocialIcon/SocialIcon.tsx
@@ -195,6 +195,11 @@ export const SocialIcon: RneFunctionComponent<SocialIconProps> = ({
             borderRadius: iconSize * 2,
           },
         { backgroundColor: type && colors[type] },
+        {
+          width: iconSize * 2 + 4,
+          height: iconSize * 2 + 4,
+          borderRadius: iconSize * 2,
+        },
         light && { backgroundColor: 'white' },
         style && style,
       ])}


### PR DESCRIPTION
What kind of change does this PR introduce?

Fixes issue #3066  and  #3065

Did you add tests for your changes?

Not needed.

If relevant, did you update the documentation?

Not relevant.

Summary

This PR fixes issues #3066 and #3065. The SocialIcon was set to change the iconSize of only the inner symbol, not the whole component when raised was set to true. Now, it would change the size of the whole component by default according to the size mentioned in the iconSize prop, irrespective of the raised prop value. These changes also solve #3065.

Does this PR introduce a breaking change?

No

@khushal87 @flyingcircle @arpitBhalla @kyler-hyuna 