### PR TITLE
Fix: Issue #3069 ListItemSubtitle is invisible in dark theme

### DIFF
--- a/src/ListItem/ListItem.Subtitle.tsx
+++ b/src/ListItem/ListItem.Subtitle.tsx
@@ -38,7 +38,6 @@ const styles = StyleSheet.create({
         fontSize: 15,
       },
       default: {
-        color: ANDROID_SECONDARY,
         fontSize: 14,
       },
     }),


### PR DESCRIPTION
What kind of change does this PR introduce?

Fixes Issue #3069.

Did you add tests for your changes?

Not needed.

If relevant, did you update the documentation?

Not relevant.

Summary

This PR fixes issue #3069. The ListItem.Subtitle was invisible in the dark theme as the default color of it was dark too. But now it would be white making it visible in a dark theme.

Does this PR introduce a breaking change?

No.

@flyingcircle @arpitBhalla @khushal87 