### PR TITLE
Fix npm and GitHub spelling

### DIFF
--- a/website/blog/2021-08-23-google-summer-of-code-arpitBhalla.md
+++ b/website/blog/2021-08-23-google-summer-of-code-arpitBhalla.md
@@ -79,7 +79,7 @@ You can find all my contributions [here](https://github.com/react-native-element
 
 ### Core Improvements
 
-- [Migrate build to Github Actions (#3101)](https://github.com/react-native-elements/react-native-elements/pull/3101)
+- [Migrate build to GitHub Actions (#3101)](https://github.com/react-native-elements/react-native-elements/pull/3101)
 - [Strict TypeScript (#2930)](https://github.com/react-native-elements/react-native-elements/pull/2930)
 - [Removed ts-ignore and transformed to Functional Component (#2834)](https://github.com/react-native-elements/react-native-elements/pull/2834)
 

--- a/website/docs/getting_started.md
+++ b/website/docs/getting_started.md
@@ -21,7 +21,7 @@ and feel.
 <Tabs
 defaultValue="npm"
 values={[
-{ label: 'NPM', value: 'npm', },
+{ label: 'npm', value: 'npm', },
 { label: 'Yarn', value: 'yarn', },
 ]
 }>
@@ -46,7 +46,7 @@ yarn add react-native-elements
 <Tabs
 defaultValue="npm"
 values={[
-{ label: 'NPM', value: 'npm', },
+{ label: 'npm', value: 'npm', },
 { label: 'Yarn', value: 'yarn', },
 ]
 }>
@@ -94,7 +94,7 @@ Manual linking of react-native-vector-icons is not necessary if you're using rea
 <Tabs
 defaultValue="npm"
 values={[
-{ label: 'NPM', value: 'npm', },
+{ label: 'npm', value: 'npm', },
 { label: 'Yarn', value: 'yarn', },
 ]
 }>
@@ -134,7 +134,7 @@ your project you can skip this step. Otherwise run the following command:
 <Tabs
 defaultValue="npm"
 values={[
-{ label: 'NPM', value: 'npm', },
+{ label: 'npm', value: 'npm', },
 { label: 'Yarn', value: 'yarn', },
 ]
 }>

--- a/website/src/components/Installation.tsx
+++ b/website/src/components/Installation.tsx
@@ -14,7 +14,7 @@ const Home: React.FunctionComponent<{}> = () => {
             </div>
             <div className="col col--7 ">
               <p>
-                <b>1. Install the React Native Elements package from the NPM</b>
+                <b>1. Install the React Native Elements package from the npm</b>
                 <p className="margin-vert--md margin-horiz--md">
                   <pre>$ npm install react-native-elements</pre>
                 </p>

--- a/website/src/components/RunOnExpo.tsx
+++ b/website/src/components/RunOnExpo.tsx
@@ -33,7 +33,7 @@ const Home: React.FunctionComponent<{}> = () => {
                   'https://github.com/react-native-elements/react-native-elements-app'
                 }
               >
-                View on Github
+                View on GitHub
               </Link>
             </div>
           </div>


### PR DESCRIPTION
Just a couple of capitalization fixes: `Github` -> `GitHub` and `NPM` -> `npm`.

npm should never be capitalized:
https://github.com/npm/cli#is-it-npm-or-npm-or-npm