### PR TITLE
Fix typo in Divider

### DIFF
--- a/website/versioned_docs/version-3.4.2/divider.md
+++ b/website/versioned_docs/version-3.4.2/divider.md
@@ -13,17 +13,17 @@ distinction between sections of content.
 ```js
 import { Divider } from 'react-native-elements';
 
-<Divider orientation="horizontal" />;
+<Divider orientation="horizontal" />
 
-<Divider orientation="vertical" width={5} />;
+<Divider orientation="vertical" width={5} />
 
-<Divider inset={true} insetType="middle" />;
+<Divider inset={true} insetType="middle" />
 
 <Divider
   orientation="horizontal"
   subHeader="Test"
   subHeaderStyle={{ color: 'blue' }}
-/>;
+/>
 ```
 
 ---


### PR DESCRIPTION
In the **Usage** section, every **Divider** component ends with a semicolon. And it differs from the other components usage sections.
This PR fixes that and keeps the consistency.