### PR TITLE
fix(ButtonGroup): update default height when vertical = true

### DIFF
--- a/src/ButtonGroup/ButtonGroup.tsx
+++ b/src/ButtonGroup/ButtonGroup.tsx
@@ -134,6 +134,7 @@ export const ButtonGroup: RneFunctionComponent<ButtonGroupProps> = ({
   ...rest
 }) => {
   let innerBorderWidth = 1;
+  const verticalContainerHeight = 40 * buttons?.length;
   if (
     innerBorderStyle &&
     Object.prototype.hasOwnProperty.call(innerBorderStyle, 'width')
@@ -147,6 +148,7 @@ export const ButtonGroup: RneFunctionComponent<ButtonGroupProps> = ({
       style={StyleSheet.flatten([
         styles.container,
         vertical && styles.verticalContainer,
+        vertical && {height: verticalContainerHeight},
         containerStyle && containerStyle,
       ])}
     >
@@ -289,7 +291,6 @@ const styles = StyleSheet.create({
   },
   verticalContainer: {
     flexDirection: 'column',
-    height: null,
   },
   verticalComponent: {
     height: 40,


### PR DESCRIPTION
When `vertical` prop is set, the `ButtonGroup`'s default `height` was set to `null`, updating that to `40 * numOfButtons`.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no

**If relevant, did you update the documentation?**
not needed (as it was expected behaviour)

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
