### PR TITLE
Fix Rotate Bug Tabview

### DIFF
--- a/src/TabView/TabView.tsx
+++ b/src/TabView/TabView.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   PanResponderGestureState,
   GestureResponderEvent,
+  useWindowDimensions
 } from 'react-native';
 import { RneFunctionComponent, ScreenWidth } from '../helpers';
 
@@ -38,6 +39,7 @@ export const TabViewBase: RneFunctionComponent<TabViewBaseProps> = ({
   const { current: translateX } = React.useRef(new Animated.Value(0));
   const currentIndex = React.useRef(value);
   const length = React.Children.count(children);
+  const window = useWindowDimensions();
 
   const onPanResponderRelease = (
     _: GestureResponderEvent,
@@ -52,7 +54,7 @@ export const TabViewBase: RneFunctionComponent<TabViewBaseProps> = ({
     if (Math.abs(dy) > Math.abs(dx)) {
       return;
     }
-    const position = dx / -ScreenWidth;
+    const position = dx / -window.width;
     const next = position > value ? Math.ceil(position) : Math.floor(position);
     onChange?.(currentIndex.current + next);
   };
@@ -84,12 +86,12 @@ export const TabViewBase: RneFunctionComponent<TabViewBaseProps> = ({
       style={[
         styles.container,
         {
-          width: ScreenWidth * length,
+          width: window.width * length,
           transform: [
             {
               translateX: translateX.interpolate({
                 inputRange: [0, 1],
-                outputRange: [0, -ScreenWidth],
+                outputRange: [0, -window.width],
               }),
             },
           ],
@@ -98,7 +100,7 @@ export const TabViewBase: RneFunctionComponent<TabViewBaseProps> = ({
       {...panResponder.panHandlers}
     >
       {React.Children.map(children, (child) => (
-        <View style={styles.container}>{child}</View>
+        <View style={[styles.container, { width: window.width }]}>{child}</View>
       ))}
     </Animated.View>
   );
@@ -108,8 +110,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     flexDirection: 'row',
-    alignItems: 'stretch',
-    width: ScreenWidth,
+    alignItems: 'stretch'
   },
 });
 

--- a/src/TabView/TabView.tsx
+++ b/src/TabView/TabView.tsx
@@ -8,7 +8,7 @@ import {
   GestureResponderEvent,
   useWindowDimensions
 } from 'react-native';
-import { RneFunctionComponent, ScreenWidth } from '../helpers';
+import { RneFunctionComponent } from '../helpers';
 
 export type TabViewBaseProps = {
   /** Child position index value. */


### PR DESCRIPTION
**What kind of change does this PR introduce?**

TabView Components Rotate
- When device rotation changes the tabview's item component width does not match the device dimensions.
- Within, there needed to change from old `Dimensions` class to the `useWindowDimensions`.

**Did you add tests for your changes?**
No, it did not need them.

**If relevant, did you update the documentation?**
No, it is not relevant.

**Does this PR introduce a breaking change?**
No, it does not.


@khushal87 @flyingcircle @arpitBhalla @kyler-hyuna