### PR TITLE
Fix issues with introduction of Pressable props in docs autogen

### DIFF
--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -115,11 +115,9 @@ export const Avatar: RneFunctionComponent<AvatarProps> = ({
 }) => {
   const width =
     typeof size === 'number' ? size : avatarSizes[size] || avatarSizes.small;
-  const ComponentProp = Component
-    ? Component
-    : onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View;
+  const ContainerComponent =
+    Component ||
+    (onPress || onLongPress || onPressIn || onPressOut ? Pressable : View);
 
   const height = width;
   const titleSize = width / 2;
@@ -162,7 +160,7 @@ export const Avatar: RneFunctionComponent<AvatarProps> = ({
   }
 
   return (
-    <ComponentProp
+    <ContainerComponent
       style={StyleSheet.flatten([
         styles.container,
         { height, width },
@@ -197,7 +195,7 @@ export const Avatar: RneFunctionComponent<AvatarProps> = ({
         ImageComponent={ImageComponent}
       />
       {children}
-    </ComponentProp>
+    </ContainerComponent>
   );
 };
 

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -94,9 +94,7 @@ export const Avatar: RneFunctionComponent<AvatarProps> = ({
   onLongPress,
   onPressIn,
   onPressOut,
-  Component = onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View,
+  Component,
   containerStyle,
   icon,
   iconStyle,
@@ -117,6 +115,11 @@ export const Avatar: RneFunctionComponent<AvatarProps> = ({
 }) => {
   const width =
     typeof size === 'number' ? size : avatarSizes[size] || avatarSizes.small;
+  const ComponentProp = Component
+    ? Component
+    : onPress || onLongPress || onPressIn || onPressOut
+    ? Pressable
+    : View;
 
   const height = width;
   const titleSize = width / 2;
@@ -159,7 +162,7 @@ export const Avatar: RneFunctionComponent<AvatarProps> = ({
   }
 
   return (
-    <Component
+    <ComponentProp
       style={StyleSheet.flatten([
         styles.container,
         { height, width },
@@ -194,7 +197,7 @@ export const Avatar: RneFunctionComponent<AvatarProps> = ({
         ImageComponent={ImageComponent}
       />
       {children}
-    </Component>
+    </ComponentProp>
   );
 };
 

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -60,18 +60,15 @@ export const Badge: RneFunctionComponent<BadgeProps> = ({
     ...textProps,
   });
 
-  const ComponentProp = Component
-    ? Component
-    : onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View;
-
+  const ContainerComponent =
+    Component ||
+    (onPress || onLongPress || onPressIn || onPressOut ? Pressable : View);
   return (
     <View
       testID="RNE__Badge__Container"
       style={StyleSheet.flatten([containerStyle && containerStyle])}
     >
-      <ComponentProp
+      <ContainerComponent
         {...{
           onPress,
           onLongPress,
@@ -98,7 +95,7 @@ export const Badge: RneFunctionComponent<BadgeProps> = ({
         ])}
       >
         {element}
-      </ComponentProp>
+      </ContainerComponent>
     </View>
   );
 };

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -48,9 +48,7 @@ export const Badge: RneFunctionComponent<BadgeProps> = ({
   onLongPress,
   onPressOut,
   onPressIn,
-  Component = onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View,
+  Component,
   value,
   theme,
   status = 'primary',
@@ -61,12 +59,19 @@ export const Badge: RneFunctionComponent<BadgeProps> = ({
     style: StyleSheet.flatten([styles.text, textStyle && textStyle]),
     ...textProps,
   });
+
+  const ComponentProp = Component
+    ? Component
+    : onPress || onLongPress || onPressIn || onPressOut
+    ? Pressable
+    : View;
+
   return (
     <View
       testID="RNE__Badge__Container"
       style={StyleSheet.flatten([containerStyle && containerStyle])}
     >
-      <Component
+      <ComponentProp
         {...{
           onPress,
           onLongPress,
@@ -93,7 +98,7 @@ export const Badge: RneFunctionComponent<BadgeProps> = ({
         ])}
       >
         {element}
-      </Component>
+      </ComponentProp>
     </View>
   );
 };

--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -110,9 +110,7 @@ export const Icon: RneFunctionComponent<IconProps> = ({
   onLongPress,
   onPressIn,
   onPressOut,
-  Component = onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View,
+  Component,
   solid = false,
   brand = false,
   theme,
@@ -123,6 +121,12 @@ export const Icon: RneFunctionComponent<IconProps> = ({
   const reverseColor = reverseColorProp || theme?.colors?.white;
   const IconComponent = getIconType(type);
   const iconSpecificStyle = getIconStyle(type, { solid, brand });
+
+  const ComponentProp = Component
+    ? Component
+    : onPress || onLongPress || onPressIn || onPressOut
+    ? Pressable
+    : View;
 
   const getBackgroundColor = React.useMemo(() => {
     if (reverse) {
@@ -156,7 +160,7 @@ export const Icon: RneFunctionComponent<IconProps> = ({
       ])}
       testID="RNE__ICON__CONTAINER"
     >
-      <Component
+      <ComponentProp
         {...{
           android_ripple: androidRipple(
             Color(reverse ? color : (underlayColor as string))
@@ -201,7 +205,7 @@ export const Icon: RneFunctionComponent<IconProps> = ({
             {...iconProps}
           />
         </View>
-      </Component>
+      </ComponentProp>
     </View>
   );
 };

--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -122,11 +122,9 @@ export const Icon: RneFunctionComponent<IconProps> = ({
   const IconComponent = getIconType(type);
   const iconSpecificStyle = getIconStyle(type, { solid, brand });
 
-  const ComponentProp = Component
-    ? Component
-    : onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View;
+  const ContainerComponent =
+    Component ||
+    (onPress || onLongPress || onPressIn || onPressOut ? Pressable : View);
 
   const getBackgroundColor = React.useMemo(() => {
     if (reverse) {
@@ -160,7 +158,7 @@ export const Icon: RneFunctionComponent<IconProps> = ({
       ])}
       testID="RNE__ICON__CONTAINER"
     >
-      <ComponentProp
+      <ContainerComponent
         {...{
           android_ripple: androidRipple(
             Color(reverse ? color : (underlayColor as string))
@@ -205,7 +203,7 @@ export const Icon: RneFunctionComponent<IconProps> = ({
             {...iconProps}
           />
         </View>
-      </ComponentProp>
+      </ContainerComponent>
     </View>
   );
 };

--- a/src/Image/Image.tsx
+++ b/src/Image/Image.tsx
@@ -54,9 +54,7 @@ export const Image: RneFunctionComponent<ImageProps> = ({
   onLongPress,
   onPressIn,
   onPressOut,
-  Component = onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View,
+  Component,
   placeholderStyle,
   PlaceholderContent,
   containerStyle,
@@ -90,8 +88,14 @@ export const Image: RneFunctionComponent<ImageProps> = ({
 
   const hasImage = Boolean(props.source);
 
+  const ComponentProp = Component
+    ? Component
+    : onPress || onLongPress || onPressIn || onPressOut
+    ? Pressable
+    : View;
+
   return (
-    <Component
+    <ComponentProp
       {...pressableProps}
       {...{ onPress, onPressIn, onPressOut, onLongPress }}
       accessibilityIgnoresInvertColors={true}
@@ -140,7 +144,7 @@ export const Image: RneFunctionComponent<ImageProps> = ({
       >
         {children}
       </View>
-    </Component>
+    </ComponentProp>
   );
 };
 

--- a/src/Image/Image.tsx
+++ b/src/Image/Image.tsx
@@ -88,14 +88,12 @@ export const Image: RneFunctionComponent<ImageProps> = ({
 
   const hasImage = Boolean(props.source);
 
-  const ComponentProp = Component
-    ? Component
-    : onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View;
+  const ContainerComponent =
+    Component ||
+    (onPress || onLongPress || onPressIn || onPressOut ? Pressable : View);
 
   return (
-    <ComponentProp
+    <ContainerComponent
       {...pressableProps}
       {...{ onPress, onPressIn, onPressOut, onLongPress }}
       accessibilityIgnoresInvertColors={true}
@@ -144,7 +142,7 @@ export const Image: RneFunctionComponent<ImageProps> = ({
       >
         {children}
       </View>
-    </ComponentProp>
+    </ContainerComponent>
   );
 };
 

--- a/src/LinearProgress/LinearProgress.tsx
+++ b/src/LinearProgress/LinearProgress.tsx
@@ -13,8 +13,7 @@ import { RneFunctionComponent } from '../helpers';
 /**
  * Keep value between 0 and 1
  */
-export const clamp = (value: number): number =>
-  Math.max(0, Math.min(value, 1)) || 0;
+const clamp = (value: number): number => Math.max(0, Math.min(value, 1)) || 0;
 
 export type LinearProgressProps = ViewProps & {
   /** The value of the progress indicator for the determinate variant. Value between 0 and 1. */

--- a/src/LinearProgress/__tests__/LinearProgress.test.tsx
+++ b/src/LinearProgress/__tests__/LinearProgress.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import LinearProgress from '../index';
-import { clamp } from '../LinearProgress';
 import { renderWithWrapper, fireEvent, act } from '../../../.ci/testHelper';
 import { FullTheme } from '../../config';
+
+/**
+ * Keep value between 0 and 1
+ */
+const clamp = (value: number): number => Math.max(0, Math.min(value, 1)) || 0;
 
 describe('LinearProgress Component', () => {
   it('should clamp', () => {

--- a/src/SocialIcon/SocialIcon.tsx
+++ b/src/SocialIcon/SocialIcon.tsx
@@ -165,9 +165,7 @@ export const SocialIcon: RneFunctionComponent<SocialIconProps> = ({
   onPress,
   onPressOut,
   onPressIn,
-  Component = onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View,
+  Component,
   raised = true,
   small,
   style,
@@ -179,8 +177,14 @@ export const SocialIcon: RneFunctionComponent<SocialIconProps> = ({
 }) => {
   const shouldShowExpandedButton = button && title;
 
+  const ComponentProp = Component
+    ? Component
+    : onPress || onLongPress || onPressIn || onPressOut
+    ? Pressable
+    : View;
+
   return (
-    <Component
+    <ComponentProp
       {...{
         onLongPress,
         onPress,
@@ -257,7 +261,7 @@ export const SocialIcon: RneFunctionComponent<SocialIconProps> = ({
           />
         )}
       </View>
-    </Component>
+    </ComponentProp>
   );
 };
 

--- a/src/SocialIcon/SocialIcon.tsx
+++ b/src/SocialIcon/SocialIcon.tsx
@@ -177,14 +177,11 @@ export const SocialIcon: RneFunctionComponent<SocialIconProps> = ({
 }) => {
   const shouldShowExpandedButton = button && title;
 
-  const ComponentProp = Component
-    ? Component
-    : onPress || onLongPress || onPressIn || onPressOut
-    ? Pressable
-    : View;
-
+  const ContainerComponent =
+    Component ||
+    (onPress || onLongPress || onPressIn || onPressOut ? Pressable : View);
   return (
-    <ComponentProp
+    <ContainerComponent
       {...{
         onLongPress,
         onPress,
@@ -261,7 +258,7 @@ export const SocialIcon: RneFunctionComponent<SocialIconProps> = ({
           />
         )}
       </View>
-    </ComponentProp>
+    </ContainerComponent>
   );
 };
 

--- a/website/docs/main/Avatar.md
+++ b/website/docs/main/Avatar.md
@@ -60,9 +60,9 @@ They are commonly used to represent a user and can contain photos, icons, or eve
 
 Component for enclosing element (eg: TouchableHighlight, View, etc).
 
-| Type            | Default           |
-| --------------- | ----------------- |
-| React Component | Pressable or View |
+| Type            | Default |
+| --------------- | ------- |
+| React Component | None    |
 
 ---
 

--- a/website/docs/main/Badge.md
+++ b/website/docs/main/Badge.md
@@ -36,9 +36,9 @@ Badges are small components typically used to communicate a numerical value or i
 
 Custom component to replace the badge outer component.
 
-| Type            | Default           |
-| --------------- | ----------------- |
-| React Component | Pressable or View |
+| Type            | Default |
+| --------------- | ------- |
+| React Component | None    |
 
 ---
 

--- a/website/docs/main/Icon.md
+++ b/website/docs/main/Icon.md
@@ -49,9 +49,9 @@ They are also used for displaying information.
 
 Update React Native Component.
 
-| Type            | Default           |
-| --------------- | ----------------- |
-| React Component | Pressable or View |
+| Type            | Default |
+| --------------- | ------- |
+| React Component | None    |
 
 ---
 

--- a/website/docs/main/Image.md
+++ b/website/docs/main/Image.md
@@ -41,9 +41,9 @@ images with a placeholder and smooth image load transitioning.
 
 Define the component passed to image.
 
-| Type            | Default           |
-| --------------- | ----------------- |
-| React Component | Pressable or View |
+| Type            | Default |
+| --------------- | ------- |
+| React Component | None    |
 
 ---
 

--- a/website/docs/main/SocialIcon.md
+++ b/website/docs/main/SocialIcon.md
@@ -48,9 +48,9 @@ SocialIcons are visual cues to online and social media networks. We offer a vari
 
 Type of button.
 
-| Type            | Default           |
-| --------------- | ----------------- |
-| React Component | Pressable or View |
+| Type            | Default |
+| --------------- | ------- |
+| React Component | None    |
 
 ---
 

--- a/website/scripts/docgen/docgenParser.ts
+++ b/website/scripts/docgen/docgenParser.ts
@@ -91,11 +91,6 @@ const parserOptions = {
       prop.type.name = 'Boolean or Object';
     }
 
-    // To replace '\r\n' which breaks the markdown for certain props to ''
-    if (prop?.defaultValue?.value.includes('\r\n')) {
-      prop.defaultValue.value = prop.defaultValue.value.replace(/\r\n/g, '');
-    }
-
     // To deal with the Badge Component with prop name onPress
     // Input - (...args: any[]) => an
     // Output - Function
@@ -117,17 +112,6 @@ const parserOptions = {
     // Output - Color(Primary)
     if (prop?.defaultValue?.value === 'theme?.colors?.primary') {
       prop.defaultValue.value = 'Color(Primary)';
-    }
-
-    // To deal with the prop of default value onPress || onLongPress ? Pressable : View in Avatar
-    // Input - onPress || onLongPress ? Pressable : View
-    // Output - Pressable or View
-    if (
-      /\? Pressable : View/.test(
-        prop?.defaultValue?.value.replace(/\n\s+/g, ' ')
-      )
-    ) {
-      prop.defaultValue.value = 'Pressable or View';
     }
 
     // Filter to show the props of the components only related to the src and ignore the props of the noe modules


### PR DESCRIPTION
This PR fixed the pressable props issue in the autogeneration of docs and also fixes the multiple exports from the LinearProgress component such that the `yarn docs:builds` runs successfully and the docs are updated automatically.

Reference - #3263 