### PR TITLE
Fix the link of TabView component

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const App = () => <Button title="Hello World!" />;
 - [x] [Switch](https://reactnativeelements.com/docs/switch)
 - [x] [Tile](https://reactnativeelements.com/docs/tile)
 - [x] [Tab](https://reactnativeelements.com/docs/tab)
-- [x] [TabView](https://reactnativeelements.com/docs/tab#tabview)
+- [x] [TabView](https://reactnativeelements.com/docs/tabview)
 - [x] [Tooltip](https://reactnativeelements.com/docs/tooltip)
 
 ## [Universe Components](https://www.npmjs.com/package/react-native-elements-universe)


### PR DESCRIPTION
TabView isn't a header under the Tab page anymore. There is a separate page for the TabView component.  I fixed the broken link with this commit.