### PR TITLE
Fix customisation page documentation

### DIFF
--- a/website/versioned_docs/version-3.4.2/customization.md
+++ b/website/versioned_docs/version-3.4.2/customization.md
@@ -99,6 +99,7 @@ TypeScript definitions for your theme can be extended by using TypeScript's [dec
 i.e. below we add a custom p1Style to the Text theme object and we add a bunch of colors to the colors object.
 
 ```typescript
+import 'react-native-elements'
 type RecursivePartial<T> = { [P in keyof T]?: RecursivePartial<T[P]> };
 
 declare module 'react-native-elements' {


### PR DESCRIPTION
Copy pasting the explanation to extend the theme does not work as expected: it overrides the initial declaration instead of extending it. (eg. "EveryComponent" does not exist in "react-native-elements")
To fix that you need to first import the package then declare again. Adding the import statement on the top does achieve the expected behavior.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
