### PR TITLE
Fix#3301 Button title alignment

### DIFF
--- a/example/src/views/lists/content.tsx
+++ b/example/src/views/lists/content.tsx
@@ -283,6 +283,7 @@ const ListContent = (props: ListContentType) => {
                   width: 120,
                   backgroundColor: 'rgba(222, 223, 226, 1)',
                   borderRadius: 5,
+                  paddingVertical: 5,
                 }}
                 titleStyle={{
                   fontFamily: 'regular',
@@ -300,6 +301,7 @@ const ListContent = (props: ListContentType) => {
                   width: 120,
                   backgroundColor: 'rgba(113, 154, 112, 1)',
                   borderRadius: 5,
+                  paddingVertical: 5,
                 }}
                 titleStyle={{
                   fontFamily: 'regular',


### PR DESCRIPTION
Centered button title alignment.
![cent](https://user-images.githubusercontent.com/59159432/150620654-4f7d903f-45e1-4f17-9566-7184e29a897e.jpeg)
.