### PR TITLE
Fix:-Fixed image link

### DIFF
--- a/example/src/views/avatars.tsx
+++ b/example/src/views/avatars.tsx
@@ -10,7 +10,7 @@ type AvatarData = {
 
 const dataList: AvatarData[] = [
   {
-    image_url: 'https://uifaces.co/our-content/donated/6MWH9Xi_.jpg',
+    image_url: 'https://api.uifaces.co/our-content/donated/xZ4wg2Xj.jpg',
   },
   {
     image_url: 'https://randomuser.me/api/portraits/men/36.jpg',


### PR DESCRIPTION
Here in the avatar, the list of the images, the first image seems to have a broken link ,i added a working link 

this is what it used to like before this PR-

![WhatsApp Image 2022-01-30 at 2 49 09 PM](https://user-images.githubusercontent.com/72331432/151694037-37337898-dd92-4120-8a90-2d687e39ec19.jpeg)
 
this is what it should look like-

![WhatsApp Image 2022-01-30 at 2 48 50 PM](https://user-images.githubusercontent.com/72331432/151694049-37567837-f73d-417c-833a-f469cbed09d1.jpeg)
