### PR TITLE
docs(Icon): fix broken link

### DIFF
--- a/website/versioned_docs/version-4.0.0-beta.0/main/Icon.md
+++ b/website/versioned_docs/version-4.0.0-beta.0/main/Icon.md
@@ -160,7 +160,7 @@ Name of the icon to show
 
 See Icon Explorer app
 
-{@link https://github.com/oblador/react-native-vector-icons/tree/master/Examples/IconExplorer}
+{ @link https://github.com/oblador/react-native-vector-icons/tree/master/Examples/IconExplorer }
 
 | Type   | Default |
 | ------ | ------- |

--- a/website/versioned_docs/version-4.0.0-beta.0/main/Icon.md
+++ b/website/versioned_docs/version-4.0.0-beta.0/main/Icon.md
@@ -158,9 +158,8 @@ Good for setting margins or a different color.
 
 Name of the icon to show
 
-See Icon Explorer app
+See [Icon Explorer app](https://github.com/oblador/react-native-vector-icons/tree/master/Examples/IconExplorer)
 
-{ @link https://github.com/oblador/react-native-vector-icons/tree/master/Examples/IconExplorer }
 
 | Type   | Default |
 | ------ | ------- |


### PR DESCRIPTION
The closing curly bracket was added to the url which then was invalid.
Fixed by adding a space.