### PR TITLE
fix(Icon): preserve custom testID property

### DIFF
--- a/packages/base/src/Icon/Icon.tsx
+++ b/packages/base/src/Icon/Icon.tsx
@@ -161,6 +161,7 @@ export const Icon: RneFunctionComponent<IconProps> = ({
       testID="RNE__ICON__CONTAINER"
     >
       <Component
+        testID="RNE__ICON__CONTAINER_ACTION"
         {...{
           android_ripple: androidRipple(
             Color(reverse ? color : (underlayColor as string))
@@ -177,7 +178,6 @@ export const Icon: RneFunctionComponent<IconProps> = ({
           ...pressableProps,
           ...rest,
         }}
-        testID="RNE__ICON__CONTAINER_ACTION"
       >
         <View
           style={StyleSheet.flatten([

--- a/packages/base/src/Icon/__tests__/Icon.test.tsx
+++ b/packages/base/src/Icon/__tests__/Icon.test.tsx
@@ -81,4 +81,11 @@ describe('Icon component', () => {
     const component = renderWithWrapper(<Icon name="wifi" raised />);
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it('should have overridable testID', () => {
+    const { queryByTestId } = renderWithWrapper(
+      <Icon name="wifi" testID="wifiIcon" />
+    );
+    expect(queryByTestId('wifiIcon')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Motivation

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3375

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Jest Unit Test
- [ ] Checked with `example` app

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->

It's simply a reordering of property assignment, so the hardcoded `testID` doesn't unintentionally overwrite a passed-in `testID` (this is how all other similar components work... `Icon` seemed to be the exception)