### PR TITLE
docs: Include example for swipeable resetCallback

### DIFF
--- a/website/docs/component_usage/ListItem.Swipeable.mdx
+++ b/website/docs/component_usage/ListItem.Swipeable.mdx
@@ -2,20 +2,22 @@
 
 ```js
 <ListItem.Swipeable
-  leftContent={
+  leftContent={(reset) => (
     <Button
       title="Info"
+      onPress={() => reset()}
       icon={{ name: 'info', color: 'white' }}
       buttonStyle={{ minHeight: '100%' }}
     />
-  }
-  rightContent={
+  )}
+  rightContent={(reset) => (
     <Button
       title="Delete"
+      onPress={() => reset()}
       icon={{ name: 'delete', color: 'white' }}
       buttonStyle={{ minHeight: '100%', backgroundColor: 'red' }}
     />
-  }
+  )}
 >
   <Icon name="My Icon" />
   <ListItem.Content>


### PR DESCRIPTION
## Motivation

To include an example for the new ListItem.Swipeable resetCallback feature referenced on https://github.com/react-native-elements/react-native-elements/pull/3180

## Type of change

Update to the docs.

# How Has This Been Tested?

- [ ] Checked with `example` app

