### PR TITLE
fix(Tooltip): removeEventListener deprecated warning

### DIFF
--- a/packages/base/src/Tooltip/Tooltip.tsx
+++ b/packages/base/src/Tooltip/Tooltip.tsx
@@ -214,10 +214,20 @@ export const Tooltip: RneFunctionComponent<TooltipProps> = ({
     isMounted.current = true;
     // Wait till element's position is calculated
     requestAnimationFrame(getElementPosition);
-    Dimensions.addEventListener('change', getElementPosition);
+    const dimensionsListener = Dimensions.addEventListener(
+      'change',
+      getElementPosition
+    );
+
     return () => {
       isMounted.current = false;
-      Dimensions.removeEventListener('change', getElementPosition);
+      if (dimensionsListener?.remove) {
+        // react-native >= 0.65.*
+        dimensionsListener.remove;
+      } else {
+        // react-native < 0.65.*
+        Dimensions.removeEventListener('change', getElementPosition);
+      }
     };
   }, [getElementPosition]);
 

--- a/packages/base/src/Tooltip/Tooltip.tsx
+++ b/packages/base/src/Tooltip/Tooltip.tsx
@@ -223,7 +223,7 @@ export const Tooltip: RneFunctionComponent<TooltipProps> = ({
       isMounted.current = false;
       if (dimensionsListener?.remove) {
         // react-native >= 0.65.*
-        dimensionsListener.remove;
+        dimensionsListener.remove();
       } else {
         // react-native < 0.65.*
         Dimensions.removeEventListener('change', getElementPosition);


### PR DESCRIPTION
## Motivation

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Jest Unit Test
- [ ] Checked with `example` app

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

`Dimentions.removeEventListener(...)` is deprecated started from RN 0.65.
https://reactnative.dev/docs/dimensions#removeeventlistener

I modified it to work well for RN 0.65+
but, it will still be warning called in RN 0.65+ until RN team officially remove `removeEventListener`.

<!-- Add any other context or screenshots about the feature request here. -->
