### PR TITLE
fix(Chip): border radius on tap

### DIFF
--- a/packages/base/src/Chip/Chip.tsx
+++ b/packages/base/src/Chip/Chip.tsx
@@ -23,6 +23,7 @@ export const Chip: RneFunctionComponent<ChipProps> = ({
         { fontSize: 14, paddingHorizontal: 2 },
         titleStyle,
       ])}
+      containerStyle={{ borderRadius: 30 }}
       buttonStyle={StyleSheet.flatten([{ borderRadius: 30 }, buttonStyle])}
       {...(onPress === undefined
         ? {


### PR DESCRIPTION

Fixes # (issue)
This changes were made in response to this issue : https://github.com/react-native-elements/react-native-elements/issues/3159
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

## Additional context
Chip animation is square but it has borderRadius, this issue only get when type="outline"
so i have added containerStyle={{ borderRadius: 30 }}.

<!-- Add any other context or screenshots about the feature request here. -->
