### PR TITLE
fix(SpeedDial.Action): wrap with pressable

### DIFF
--- a/packages/base/src/SpeedDial/SpeedDial.Action.tsx
+++ b/packages/base/src/SpeedDial/SpeedDial.Action.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { Pressable, Text, StyleSheet } from 'react-native';
 import { FAB, FABProps } from '../FAB/index';
 import { RneFunctionComponent } from '../helpers';
 
@@ -10,13 +10,19 @@ export interface SpeedDialActionProps extends Omit<FABProps, 'size'> {}
 export const SpeedDialAction: RneFunctionComponent<SpeedDialActionProps> = ({
   title,
   titleStyle,
+  onPress,
   ...actionProps
 }) => {
   return (
-    <View style={styles.action}>
+    <Pressable onPress={onPress} style={styles.action}>
       {title && <Text style={[styles.title, titleStyle]}>{title}</Text>}
-      <FAB {...actionProps} size="small" style={[actionProps.style]} />
-    </View>
+      <FAB
+        {...actionProps}
+        onPress={onPress}
+        size="small"
+        style={[actionProps.style]}
+      />
+    </Pressable>
   );
 };
 

--- a/packages/base/src/SpeedDial/__tests__/SpeedDial.Action.test.tsx
+++ b/packages/base/src/SpeedDial/__tests__/SpeedDial.Action.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { SpeedDial } from '..';
+import { renderWithWrapper } from '../../../.ci/testHelper';
+
+describe('Speed Dial Action', () => {
+  it('should have onPress event', () => {
+    const onPress = jest.fn();
+    const { getByText } = renderWithWrapper(
+      <SpeedDial.Action
+        icon={{ name: 'delete', color: '#fff' }}
+        title="Delete"
+        onPress={onPress}
+      />
+    );
+    const title = getByText('Delete');
+    fireEvent(title, 'press');
+    expect(onPress).toHaveBeenCalled();
+  });
+});

--- a/packages/base/src/SpeedDial/__tests__/__snapshots__/SpeedDial.test.tsx.snap
+++ b/packages/base/src/SpeedDial/__tests__/__snapshots__/SpeedDial.test.tsx.snap
@@ -83,6 +83,18 @@ exports[`Speed Dial Component should match snapshot 1`] = `
         }
       >
         <View
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "alignItems": "center",
@@ -263,6 +275,18 @@ exports[`Speed Dial Component should match snapshot 1`] = `
         }
       >
         <View
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "alignItems": "center",

--- a/packages/themed/src/SpeedDial/__tests__/__snapshots__/SpeedDial.test.tsx.snap
+++ b/packages/themed/src/SpeedDial/__tests__/__snapshots__/SpeedDial.test.tsx.snap
@@ -83,6 +83,18 @@ exports[`Speed Dial Component should render 1`] = `
         }
       >
         <View
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "alignItems": "center",
@@ -263,6 +275,18 @@ exports[`Speed Dial Component should render 1`] = `
         }
       >
         <View
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "alignItems": "center",


### PR DESCRIPTION
Pressing the title will now also trigger the action.

## Motivation

Pressing the speed dial actions sometimes does not trigger the onPress event. This may be due to the fact that the titles are not pressable.

Fixes #3463

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


- [x] Jest Unit Test
- [x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context
