### PR TITLE
website: remove git.io link from blog

### DIFF
--- a/website/blog/2018-12-13-react-native-web.md
+++ b/website/blog/2018-12-13-react-native-web.md
@@ -618,7 +618,7 @@ Here is how to fix #2:
 
 Inside the project, run script below from your favourite terminal
 
-    $ curl -L https://git.io/fix-rn-xcode10 | bash
+    $ curl -L https://gist.githubusercontent.com/fiznool/739b8e592596b5731512edfd77a1a2e9/raw/e0123e0b2382e127f1cfd6e28228315f1299738f/fix-rn-xcode10.sh | bash
 
 If you run `yarn ios` again, and you got this error
 


### PR DESCRIPTION
## Motivation

All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/

## Type of change

<!-- Please delete options that are not relevant. -->

- Document Update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Jest Unit Test
- [x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
