### PR TITLE
fix(Tooltip): add default value in measure component

### DIFF
--- a/packages/base/src/Tooltip/Tooltip.tsx
+++ b/packages/base/src/Tooltip/Tooltip.tsx
@@ -122,10 +122,10 @@ export const Tooltip: RneFunctionComponent<TooltipProps> = ({
       (
         _frameOffsetX,
         _frameOffsetY,
-        _width,
-        _height,
-        pageOffsetX,
-        pageOffsetY
+        _width = 0,
+        _height = 0,
+        pageOffsetX = 0,
+        pageOffsetY = 0
       ) => {
         isMounted.current &&
           setDimensions({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3821,7 +3821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rneui/base@4.0.0-rc.3, @rneui/base@workspace:packages/base":
+"@rneui/base@4.0.0-rc.4, @rneui/base@workspace:packages/base":
   version: 0.0.0-use.local
   resolution: "@rneui/base@workspace:packages/base"
   dependencies:
@@ -3837,7 +3837,7 @@ __metadata:
     react-native-size-matters: ^0.4.0
     react-native-vector-icons: ^7.1.0
   peerDependencies:
-    react-native-safe-area-context: ^3.1.9
+    react-native-safe-area-context: ^3.1.9 || ^4.0.0
     react-native-vector-icons: ">7.0.0"
   languageName: unknown
   linkType: soft
@@ -3853,9 +3853,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rneui/themed@workspace:packages/themed"
   dependencies:
-    "@rneui/base": 4.0.0-rc.3
+    "@rneui/base": 4.0.0-rc.4
   peerDependencies:
-    "@rneui/base": 4.0.0-rc.3
+    "@rneui/base": 4.0.0-rc.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Motivation

If the tooltip got rendered in an FlatList an Tooltip render error could occur when running in an simulator with hermes.

`Invariant Violation: [9217,"RCTView",11,{"position":"absolute","top":"<>","backgroundColor":0,"overflow":"visible"}] is not usable as a native method argument`

Setting the default values fixed this.
Also described here already from another user:
https://github.com/react-native-elements/react-native-elements/issues/2237#issuecomment-790443657

Fixes maybe this one #3085

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with locally adapt in the source code on Expo sample app

- [x] Jest Unit Test
- [ ] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
