### PR TITLE
fix:  typo when exporting colors types

### DIFF
--- a/packages/themed/src/config/index.ts
+++ b/packages/themed/src/config/index.ts
@@ -13,7 +13,7 @@ import {
   ScreenWidth,
   registerCustomIconType,
 } from '@rneui/base/dist/helpers';
-import type { Colors, darkColors, lightColors } from './colors';
+import { Colors, darkColors, lightColors } from './colors';
 import {
   ReplaceTheme,
   UpdateTheme,

--- a/packages/themed/src/config/index.ts
+++ b/packages/themed/src/config/index.ts
@@ -13,7 +13,7 @@ import {
   ScreenWidth,
   registerCustomIconType,
 } from '@rneui/base/dist/helpers';
-import { type Colors, darkColors, lightColors } from './colors';
+import type { Colors, darkColors, lightColors } from './colors';
 import {
   ReplaceTheme,
   UpdateTheme,


### PR DESCRIPTION
## Motivation

Fix Typo on declaration file at colors import, which was generating an error when compiling typescript.

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3579 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Jest Unit Test
- [ x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
