### PR TITLE
add children to BottomSheetProps

### DIFF
--- a/packages/base/src/BottomSheet/BottomSheet.tsx
+++ b/packages/base/src/BottomSheet/BottomSheet.tsx
@@ -31,6 +31,9 @@ export interface BottomSheetProps {
 
   /** Used to add props to Scroll view. */
   scrollViewProps?: ScrollViewProps;
+
+  /** The content inside of the bottom sheet */
+  children?: React.ReactNode;
 }
 
 /**


### PR DESCRIPTION
## Motivation

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Checked with `example` app

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->

Add `children` as an optional prop in `BottomSheetProps` to avoid typescript complaining about the non-existent property.
