### PR TITLE
fix: property 'children' does not exist in React 18

### DIFF
--- a/packages/themed/src/config/withTheme.tsx
+++ b/packages/themed/src/config/withTheme.tsx
@@ -85,7 +85,11 @@ interface ThemeProps<T = {}> {
 function withTheme<P = {}, T = {}>(
   WrappedComponent: React.ComponentType<P & ThemeProps<T>>,
   themeKey?: string
-): React.FunctionComponent<P> | React.ForwardRefExoticComponent<P> {
+):
+  | React.FunctionComponent<React.PropsWithChildren<P>>
+  | React.ForwardRefExoticComponent<
+      React.RefAttributes<React.PropsWithChildren<P>>
+    > {
   const name = themeKey
     ? `Themed.${themeKey}`
     : `Themed.${


### PR DESCRIPTION
## Motivation

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3628

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Jest Unit Test
- [ ] Checked with `example` app

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
