### PR TITLE
feat(Header): add edges support for SafeAreaView

### DIFF
--- a/packages/base/src/Header/Header.tsx
+++ b/packages/base/src/Header/Header.tsx
@@ -75,6 +75,9 @@ export interface HeaderProps extends ViewProps {
 
   /** Elevation for header */
   elevated?: boolean;
+
+  /** SafeAreaView edges control. */
+  edges?: Array<string>;
 }
 
 /** Headers are navigation components that display information and actions relating to the current screen.

--- a/packages/base/src/Header/Header.tsx
+++ b/packages/base/src/Header/Header.tsx
@@ -77,7 +77,7 @@ export interface HeaderProps extends ViewProps {
   elevated?: boolean;
 
   /** SafeAreaView edges control. */
-  edges?: Array<Edge>;
+  edges?: Edge[];
 }
 
 /** Headers are navigation components that display information and actions relating to the current screen.
@@ -105,7 +105,7 @@ export const Header: RneFunctionComponent<HeaderProps> = ({
     : ImageBackground,
   theme = defaultTheme,
   elevated,
-  edges = ['left' as Edge, 'top' as Edge, 'right' as Edge],
+  edges = ['left', 'top', 'right'],
   ...rest
 }) => {
   React.useEffect(() => {

--- a/packages/base/src/Header/Header.tsx
+++ b/packages/base/src/Header/Header.tsx
@@ -102,6 +102,7 @@ export const Header: RneFunctionComponent<HeaderProps> = ({
     : ImageBackground,
   theme = defaultTheme,
   elevated,
+  edges = ['left', 'top', 'right'],
   ...rest
 }) => {
   React.useEffect(() => {
@@ -143,7 +144,7 @@ export const Header: RneFunctionComponent<HeaderProps> = ({
         {...linearGradientProps}
       >
         <SafeAreaView
-          edges={['left', 'top', 'right']}
+          edges={edges}
           style={styles.headerSafeView}
         >
           <Children

--- a/packages/base/src/Header/Header.tsx
+++ b/packages/base/src/Header/Header.tsx
@@ -77,7 +77,7 @@ export interface HeaderProps extends ViewProps {
   elevated?: boolean;
 
   /** SafeAreaView edges control. */
-  edges?: Array<Edge>[];
+  edges?: Array<Edge>;
 }
 
 /** Headers are navigation components that display information and actions relating to the current screen.

--- a/packages/base/src/Header/Header.tsx
+++ b/packages/base/src/Header/Header.tsx
@@ -146,10 +146,7 @@ export const Header: RneFunctionComponent<HeaderProps> = ({
         imageStyle={backgroundImageStyle}
         {...linearGradientProps}
       >
-        <SafeAreaView
-          edges={edges}
-          style={styles.headerSafeView}
-        >
+        <SafeAreaView edges={edges} style={styles.headerSafeView}>
           <Children
             style={StyleSheet.flatten([
               placement === 'center' && styles.rightLeftContainer,

--- a/packages/base/src/Header/Header.tsx
+++ b/packages/base/src/Header/Header.tsx
@@ -14,7 +14,7 @@ import {
   ImageStyle,
   ViewStyle,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, Edge } from 'react-native-safe-area-context';
 import { defaultTheme, RneFunctionComponent } from '../helpers';
 import { Children } from './components/HeaderChildren';
 import { HeaderIcon } from './components/HeaderIcon';
@@ -77,7 +77,7 @@ export interface HeaderProps extends ViewProps {
   elevated?: boolean;
 
   /** SafeAreaView edges control. */
-  edges?: Array<string>;
+  edges?: Array<Edge>[];
 }
 
 /** Headers are navigation components that display information and actions relating to the current screen.
@@ -105,7 +105,7 @@ export const Header: RneFunctionComponent<HeaderProps> = ({
     : ImageBackground,
   theme = defaultTheme,
   elevated,
-  edges = ['left', 'top', 'right'],
+  edges = ['left' as Edge, 'top' as Edge, 'right' as Edge],
   ...rest
 }) => {
   React.useEffect(() => {

--- a/website/docs/components/Header.mdx
+++ b/website/docs/components/Header.mdx
@@ -49,25 +49,26 @@ Includes all [View](https://reactnative.dev/docs/view#props) props.
 
 <div class='table-responsive'>
 
-| Name                   | Type                                   | Default  | Description                                                     |
-| ---------------------- | -------------------------------------- | -------- | --------------------------------------------------------------- |
-| `ViewComponent`        | React Component                        | `View`   | Component for container.                                        |
-| `backgroundColor`      | string                                 |          | Sets backgroundColor of the parent component.                   |
-| `backgroundImage`      | ImageSourcePropType                    |          | Sets backgroundImage for parent component.                      |
-| `backgroundImageStyle` | ImageStyle                             |          | Styling for backgroundImage in the main container.              |
-| `barStyle`             | StatusBarStyle                         |          | Sets the color of the status bar text.                          |
-| `centerComponent`      | HeaderSubComponent                     |          | Define your center component here.                              |
-| `centerContainerStyle` | View Style                             |          | Styling for container around the centerComponent.               |
-| `children`             | `(Element` \| `Element[]) & ReactNode` | `[]`     | Add children component to the header.                           |
-| `containerStyle`       | View Style                             |          | Styling around the main container.                              |
-| `elevated`             | boolean                                |          | Elevation for header                                            |
-| `leftComponent`        | HeaderSubComponent                     |          | Define your left component here.                                |
-| `leftContainerStyle`   | View Style                             |          | Styling for container around the leftComponent.                 |
-| `linearGradientProps`  | Object                                 |          | Displays a linear gradient. See [usage](#lineargradient-usage). |
-| `placement`            | `center` \| `left` \| `right`          | `center` | Alignment for title.                                            |
-| `rightComponent`       | HeaderSubComponent                     |          | Define your right component here.                               |
-| `rightContainerStyle`  | View Style                             |          | Styling for container around the rightComponent.                |
-| `statusBarProps`       | StatusBarProps                         |          | Accepts all props for StatusBar.                                |
+| Name                   | Type                                   | Default                    | Description                                                     |
+| ---------------------- | -------------------------------------- | -------------------------- | --------------------------------------------------------------- |
+| `ViewComponent`        | React Component                        | `View`                     | Component for container.                                        |
+| `backgroundColor`      | string                                 |                            | Sets backgroundColor of the parent component.                   |
+| `backgroundImage`      | ImageSourcePropType                    |                            | Sets backgroundImage for parent component.                      |
+| `backgroundImageStyle` | ImageStyle                             |                            | Styling for backgroundImage in the main container.              |
+| `barStyle`             | StatusBarStyle                         |                            | Sets the color of the status bar text.                          |
+| `centerComponent`      | HeaderSubComponent                     |                            | Define your center component here.                              |
+| `centerContainerStyle` | View Style                             |                            | Styling for container around the centerComponent.               |
+| `children`             | `(Element` \| `Element[]) & ReactNode` | `[]`                       | Add children component to the header.                           |
+| `containerStyle`       | View Style                             |                            | Styling around the main container.                              |
+| `edges`                | Edge[]                                 | `['left', 'top', 'right']` | SafeAreaView edges control.                                     |
+| `elevated`             | boolean                                |                            | Elevation for header                                            |
+| `leftComponent`        | HeaderSubComponent                     |                            | Define your left component here.                                |
+| `leftContainerStyle`   | View Style                             |                            | Styling for container around the leftComponent.                 |
+| `linearGradientProps`  | Object                                 |                            | Displays a linear gradient. See [usage](#lineargradient-usage). |
+| `placement`            | `center` \| `left` \| `right`          | `center`                   | Alignment for title.                                            |
+| `rightComponent`       | HeaderSubComponent                     |                            | Define your right component here.                               |
+| `rightContainerStyle`  | View Style                             |                            | Styling for container around the rightComponent.                |
+| `statusBarProps`       | StatusBarProps                         |                            | Accepts all props for StatusBar.                                |
 
 </div>
 


### PR DESCRIPTION
…pport proper padding disable for web

## Motivation

I was having issues using the header within a modal, which is a very useful component, and I am sure there could be other use cases. To be able to control the SafeAreaView edges, because on a PWA particularly this causes extra padding etc in unwanted areas.

Fixes # Header SafeAreaViews that I have somewhat seen could have been maybe fixed within the issues backlog.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X ] New feature (non-breaking change which adds functionality)
- [X ] This change requires a documentation update

# How Has This Been Tested?

I have used the project change within my own code base to test and ran existing tests to make sure no breaking changes would occur.

- [X ] Checked with `example` app

## Checklist

- [ X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
