### PR TITLE
fix tab indicator when app is in RTL orientation

### DIFF
--- a/packages/base/src/Tab/Tab.tsx
+++ b/packages/base/src/Tab/Tab.tsx
@@ -162,9 +162,9 @@ export const TabBase: RneFunctionComponent<TabProps> = ({
       return 0;
     }
     const inputRange = Array.from(Array(countItems + 1).keys());
-    const outputRange = tabItemPositions.current.map(({ position }) =>
-    I18nManager.isRTL ? -position : position
-  );
+    const outputRange = tabItemPositions.current.map(
+      ({ position }) => 18nManager.isRTL ? -position : position
+    );
     if (inputRange.length - 1 !== outputRange.length) {
       return 0;
     }

--- a/packages/base/src/Tab/Tab.tsx
+++ b/packages/base/src/Tab/Tab.tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   ScrollView,
   LayoutChangeEvent,
+  I18nManager,
 } from 'react-native';
 import { ParentProps } from './Tab.Item';
 import { defaultTheme, RneFunctionComponent } from '../helpers';
@@ -161,9 +162,9 @@ export const TabBase: RneFunctionComponent<TabProps> = ({
       return 0;
     }
     const inputRange = Array.from(Array(countItems + 1).keys());
-    const outputRange = tabItemPositions.current.map(
-      ({ position }) => position
-    );
+    const outputRange = tabItemPositions.current.map(({ position }) =>
+    I18nManager.isRTL ? -position : position
+  );
     if (inputRange.length - 1 !== outputRange.length) {
       return 0;
     }


### PR DESCRIPTION
## Motivation

When app is in Right to Left orientation, in the tab view the tab highlighter does not move from Right to Left which makes it difficult for the user to identify which tab they are currently on.

Fixes #3737

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Checked with `example` app
- [x] Checked with my personal app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Co-author
@tilak-puli

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->

https://user-images.githubusercontent.com/68894211/231439403-9023ad95-47f1-4f18-a6c7-cb3db4de3f04.mov

