### PR TITLE
fix(Divider): borderBottomWidth error when the width is a percentage 

### DIFF
--- a/packages/base/src/Divider/Divider.tsx
+++ b/packages/base/src/Divider/Divider.tsx
@@ -65,6 +65,7 @@ export const Divider: RneFunctionComponent<DividerProps> = ({
             ? styles.rightInset
             : { ...styles.leftInset, ...styles.rightInset }),
         orientation === 'vertical' && styles.vertical,
+        // check if width is a number to avoid passing style={{ width: NaN }}
         (width && !isNaN(width)) &&
           (orientation === 'horizontal'
             ? { borderBottomWidth: width }

--- a/packages/base/src/Divider/Divider.tsx
+++ b/packages/base/src/Divider/Divider.tsx
@@ -65,7 +65,7 @@ export const Divider: RneFunctionComponent<DividerProps> = ({
             ? styles.rightInset
             : { ...styles.leftInset, ...styles.rightInset }),
         orientation === 'vertical' && styles.vertical,
-        width &&
+        (width && !isNaN(width)) &&
           (orientation === 'horizontal'
             ? { borderBottomWidth: width }
             : { borderRightWidth: width }),


### PR DESCRIPTION
- Error when the width is a percentage. Ex: 90%

## Motivation

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Jest Unit Test
- [x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
