### PR TITLE
fix(Slider): center thumb on pressed location of the track

### DIFF
--- a/example/src/views/sliders.tsx
+++ b/example/src/views/sliders.tsx
@@ -30,7 +30,7 @@ const Sliders: React.FunctionComponent<SlidersComponentProps> = () => {
         <Slider
           value={value}
           onValueChange={setValue}
-          maximumValue={10}
+          maximumValue={100}
           minimumValue={0}
           step={1}
           allowTouchTrack


### PR DESCRIPTION
## Motivation

1. When the Slider prop `allowTouchTrack` is set to `true`, I expect the center of the thumb to be positioned over my tapped location. Currently, it aligns to the left of the thumb instead of the center.
2. When `allowTouchTrack` is `false`, I can tap anywhere inside the thumb and the thumb position does not change until I begin dragging. But if `allowTouchTrack` is `true`, the thumb will immediately left-align itself when I tap anywhere inside the thumb. I expect this behavior of tapping and dragging the thumb to be consistent no matter what the value of `allowTouchTrack` is.

You can see both issues in the video below. You can reproduce the issue in the Slider examples in the example app.

| Before | After |
|--------|--------|
| <video src="https://github.com/react-native-elements/react-native-elements/assets/1175555/162e2763-67bd-4abd-9d82-27306bc429b1" /> | <video src="https://github.com/react-native-elements/react-native-elements/assets/1175555/feadfafb-790b-464c-b89e-a1bed53a0e41" /> |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've manually tested the changed behavior using the example app on an iOS iPhone 14 simulator.

- [ ] Jest Unit Test
- [x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

N/A
