### PR TITLE
fix(ButtonGroup): add accessibility role to ButtonGroup Text

### DIFF
--- a/packages/base/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/base/src/ButtonGroup/ButtonGroup.tsx
@@ -232,6 +232,8 @@ export const ButtonGroup: RneFunctionComponent<ButtonGroupProps> = ({
                   <button.element isSelected={isSelected} />
                 ) : (
                   <Text
+                    accessibilityRole="button"
+                    accessibilityState={{selected: isSelected}}
                     testID="buttonGroupItemText"
                     style={StyleSheet.flatten([
                       {


### PR DESCRIPTION
## Motivation
The individual buttons created in ButtonGroup are non-compliant with Accessibility because they lack a Role, so the screen reader only mentions the text but not that the element is actionable. This PR adds the Accessibility Role 'button' since the components created in ButtonGroup are effectively buttons.

Fixes # (issue)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [X] Checked with `example` app

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules