### PR TITLE
fix(makeStyles): Fix object literal outside useMemo causing styles to change on every render

### DIFF
--- a/packages/themed/src/config/makeStyles.ts
+++ b/packages/themed/src/config/makeStyles.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { StyleSheet } from 'react-native';
+import { useTheme } from './ThemeProvider';
 import { Colors } from './colors';
 import { Theme } from './theme';
-import { useTheme } from './ThemeProvider';
 
 export const makeStyles =
   <T extends StyleSheet.NamedStyles<T> | StyleSheet.NamedStyles<any>, V>(
@@ -19,7 +19,10 @@ export const makeStyles =
     const { theme } = useTheme();
 
     return useMemo(() => {
-      const css = typeof styles === 'function' ? styles(theme, props ?? ({} as any)) : styles;
+      const css =
+        typeof styles === 'function'
+          ? styles(theme, props ?? ({} as any))
+          : styles;
       return StyleSheet.create(css);
     }, [props, theme]);
   };

--- a/packages/themed/src/config/makeStyles.ts
+++ b/packages/themed/src/config/makeStyles.ts
@@ -15,7 +15,7 @@ export const makeStyles =
           props: V
         ) => T)
   ) =>
-  (props: V): T => {
+  (props?: V): T => {
     const { theme } = useTheme();
 
     return useMemo(() => {

--- a/packages/themed/src/config/makeStyles.ts
+++ b/packages/themed/src/config/makeStyles.ts
@@ -15,11 +15,11 @@ export const makeStyles =
           props: V
         ) => T)
   ) =>
-  (props: V = {} as any): T => {
+  (props: V): T => {
     const { theme } = useTheme();
 
     return useMemo(() => {
-      const css = typeof styles === 'function' ? styles(theme, props) : styles;
+      const css = typeof styles === 'function' ? styles(theme, props ?? ({} as any)) : styles;
       return StyleSheet.create(css);
     }, [props, theme]);
   };


### PR DESCRIPTION
## Motivation

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We found that the return value of `makeStyles` was changing on every render, which impacts performance, and makes it impossible to use it as a dependency of `useMemo` etc. without getting a "maximum update depth exceeded" error.

This change resolves this issue by ensuring the empty object literal used when no props are given is created inside the `useMemo`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Jest Unit Test
- [ ] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
