### PR TITLE
[BottomSheet] add customizable fade animation

### DIFF
--- a/example/src/views/bottomsheet.tsx
+++ b/example/src/views/bottomsheet.tsx
@@ -30,6 +30,8 @@ const BottomSheetComponent: React.FunctionComponent<
       />
       <BottomSheet
         modalProps={{}}
+        animationType="slide"
+        animationDuration={300}
         onBackdropPress={() => setIsVisible(false)}
         isVisible={isVisible}
       >

--- a/packages/base/src/BottomSheet/__tests__/__snapshots__/BottomSheet.test.tsx.snap
+++ b/packages/base/src/BottomSheet/__tests__/__snapshots__/BottomSheet.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`BottomSheet Component renders correctly 1`] = `
   testID="wrapper"
 >
   <Modal
-    animationType="slide"
+    animationType="none"
     hardwareAccelerated={false}
     onRequestClose={[Function]}
     transparent={true}
@@ -25,16 +25,15 @@ exports[`BottomSheet Component renders correctly 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        [
-          {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
-          undefined,
-        ]
+        {
+          "backgroundColor": "rgba(0,0,0,0.2)",
+          "bottom": 0,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
       }
       testID="RNE__Overlay__backdrop"
     />
@@ -50,13 +49,25 @@ exports[`BottomSheet Component renders correctly 1`] = `
       pointerEvents="box-none"
       style={
         {
-          "backgroundColor": "rgba(0,0,0,0.2)",
           "flex": 1,
           "flexDirection": "column-reverse",
+          "opacity": 0,
         }
       }
     >
-      <View>
+      <View
+        collapsable={false}
+        onLayout={[Function]}
+        style={
+          {
+            "transform": [
+              {
+                "translateY": 0,
+              },
+            ],
+          }
+        }
+      >
         <RCTScrollView>
           <View>
             <View>

--- a/packages/base/src/BottomSheet/useBottomSheetAnimationConfig.ts
+++ b/packages/base/src/BottomSheet/useBottomSheetAnimationConfig.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Animated, ViewProps, ModalProps } from 'react-native';
+
+export interface BottomSheetAnimationConfigProps {
+  animationDuration: number;
+  isVisible: boolean;
+  animationType: ModalProps['animationType'];
+  easing?: Animated.TimingAnimationConfig['easing'];
+}
+
+const useBottomSheetAnimationConfig = ({
+  animationDuration,
+  isVisible,
+  animationType,
+  easing: _easing,
+}: BottomSheetAnimationConfigProps) => {
+  const [isVisibleWithAnimationDelay, setIsVisibleWithAnimationDelay] =
+    useState(isVisible);
+  const fadeValue = useRef(new Animated.Value(0)).current;
+  const translateYValue = useRef(new Animated.Value(0)).current;
+  const [contentContainerHeight, setContentContainerHeight] = useState(0);
+  const easing = useRef(_easing).current;
+
+  const animate = useCallback(
+    (visible) => {
+      if (visible) {
+        setIsVisibleWithAnimationDelay(true);
+      }
+      if (!contentContainerHeight) {
+        return null;
+      }
+      const fadeAnimation = Animated.timing(fadeValue, {
+        toValue: visible ? 1 : 0,
+        duration: animationDuration,
+        easing,
+        useNativeDriver: true,
+      });
+      fadeAnimation.start(
+        !visible ? () => setIsVisibleWithAnimationDelay(false) : undefined
+      );
+
+      const translateAnimation = Animated.timing(translateYValue, {
+        toValue: visible ? 0 : contentContainerHeight,
+        duration: animationDuration,
+        easing,
+        useNativeDriver: true,
+      });
+      if (animationType === 'slide') {
+        translateAnimation.start();
+      }
+
+      return () => {
+        fadeAnimation.stop();
+        translateAnimation.stop();
+      };
+    },
+    [
+      animationDuration,
+      animationType,
+      contentContainerHeight,
+      easing,
+      fadeValue,
+      translateYValue,
+    ]
+  );
+
+  useEffect(() => {
+    if (animationType === 'none') {
+      setIsVisibleWithAnimationDelay(isVisible);
+      fadeValue.setValue(1);
+      translateYValue.setValue(0);
+      return;
+    }
+
+    animate(isVisible);
+  }, [animate, animationType, fadeValue, isVisible, translateYValue]);
+
+  const onContentContainerLayout: ViewProps['onLayout'] = useCallback(
+    (e) => {
+      setContentContainerHeight((prev) => {
+        if (!prev && animationType !== 'none') {
+          translateYValue.setValue(e.nativeEvent.layout.height);
+        }
+        return e.nativeEvent.layout.height;
+      });
+    },
+    [animationType, translateYValue]
+  );
+
+  return {
+    onContentContainerLayout,
+    isVisibleWithAnimationDelay,
+    fadeValue,
+    translateYValue,
+    contentContainerHeight,
+  };
+};
+
+export default useBottomSheetAnimationConfig;

--- a/website/docs/components/BottomSheet.mdx
+++ b/website/docs/components/BottomSheet.mdx
@@ -44,14 +44,17 @@ This opens from the bottom of the screen.
 
 <div class='table-responsive'>
 
-| Name              | Type            | Default    | Description                                                                          |
-| ----------------- | --------------- | ---------- | ------------------------------------------------------------------------------------ |
-| `backdropStyle`   | View Style      |            | Style of the backdrop container.                                                     |
-| `containerStyle`  | View Style      |            | Style of the bottom sheet's container. Use this to change the color of the underlay. |
-| `isVisible`       | boolean         | `false`    | Is the modal component shown.                                                        |
-| `modalProps`      | ModalProps      | `{}`       | Additional props handed to the `Modal`.                                              |
-| `onBackdropPress` | Function        | `Function` | Handler for backdrop press.                                                          |
-| `scrollViewProps` | ScrollViewProps | `{}`       | Used to add props to Scroll view.                                                    |
+| Name                | Type                        | Default               | Description                                                                          |
+| ------------------- | --------------------------- | --------------------- | ------------------------------------------------------------------------------------ |
+| `animationDuration` | number                      | `300`                 | Duration of backdrop fade and sheet translate.                                       |
+| `animationType`     | `none` \| `slide` \| `fade` | `slide`               | Animation type.                                                                      |
+| `backdropStyle`     | View Style                  |                       | Style of the backdrop container.                                                     |
+| `containerStyle`    | View Style                  |                       | Style of the bottom sheet's container. Use this to change the color of the underlay. |
+| `easing`            | (value: number) => number   | `Easing.elastic(0.7)` | Easing config.                                                                       |
+| `isVisible`         | boolean                     | `false`               | Is the modal component shown.                                                        |
+| `modalProps`        | ModalProps                  | `{}`                  | Additional props handed to the `Modal`.                                              |
+| `onBackdropPress`   | Function                    | `Function`            | Handler for backdrop press.                                                          |
+| `scrollViewProps`   | ScrollViewProps             | `{}`                  | Used to add props to Scroll view.                                                    |
 
 </div>
 


### PR DESCRIPTION
## Motivation

The current animation for displaying the BottomSheet relies on a modal approach, resulting in the backdrop appearing simultaneously with the content at the bottom of the screen.


https://github.com/react-native-elements/react-native-elements/assets/12899080/5c788b29-8b89-4101-9cc7-c212b7c315bb


Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
   > Extension is fully backward compatible, except of `backgroundColor` moved from `safeAreaView` styles to `backdrop` styles which are also customizable
- [x] This change requires a documentation update
   Added new properties

# How Has This Been Tested?

Run example BottomSheet

- [x] Jest Unit Test
- [x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

Slide


https://github.com/react-native-elements/react-native-elements/assets/12899080/b1163630-d21f-4380-8e2c-4aad05a53c54

Fade

https://github.com/react-native-elements/react-native-elements/assets/12899080/c8fcae66-a3f9-4df4-bce4-42d0385634c3


None


https://github.com/react-native-elements/react-native-elements/assets/12899080/8b753da6-2129-4de2-acfb-89771c39576d
 


