### PR TITLE
fix(makeStyles): make props mandatory when declared non-empty

### DIFF
--- a/packages/themed/src/config/makeStyles.ts
+++ b/packages/themed/src/config/makeStyles.ts
@@ -14,8 +14,8 @@ export const makeStyles =
           } & Theme,
           props: V
         ) => T)
-  ) =>
-  (props: V = {} as any): T => {
+  ): keyof V extends undefined ? (props?: V) => T : (props: V) => T =>
+  (props: V | undefined): T => {
     const { theme } = useTheme();
 
     return useMemo(() => {


### PR DESCRIPTION
## Motivation

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently `makeStyles` always returns a function which optionally requires `props`.
I think this is a typings bug because `props` should be required if the props are needed to create the styles.
With my change if you specify a non empty type for the props the argument of the returned function would be required, otherwise optional.

```ts
export interface MyComponentStyleProps {}
export interface MyComponentProps extends MyComponentStyleProps {
  [...]
}

const MyComponent: FC<MyComponentProps> = ({[...]}) => {
  const styles = useStyles();

  return (
    <AnotherComponent />
  );
};

const useStyles = makeStyles((theme, props: MyComponentStyleProps) => ({
  [...]
}));
```

Since `MyComponentStyleProps` is an empty object `props` would not be required.

```ts
const MyComponent: FC<MyComponentProps> = ({[...]}) => {
  const styles = useStyles();

  return (
    <AnotherComponent />
  );
};

const useStyles = makeStyles((theme, props) => ({
  [...]
}));
```

If you don't specify a type `props` wouldn't be required either.

```ts
export interface MyComponentStyleProps {
  customStyle: any;
}
export interface MyComponentProps extends MyComponentStyleProps {
  [...]
}

const MyComponent: FC<MyComponentProps> = ({
  customStyle,
  [...]
}) => {
  const styles = useStyles({customStyle});

  return (
    <AnotherComponent />
  );
};

const useStyles = makeStyles((theme, props: MyComponentStyleProps) => ({
  [...]
}));
```

Now you will have to specify `props` otherwise `useStyles` will error out.

I would have rather preferred to let the user specify the generic (ex. `makeStyles<MyComponentStyleProps>((theme, props)`) but that would force you to specify all generics so you won't be able to infer the stylesheet type for the second generic.
Once https://github.com/microsoft/TypeScript/pull/54047 gets merged it should be possible to do so.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Jest Unit Test
- [ ] Checked with `example` app
- [x] Checked with production app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
