### PR TITLE
fix(SearchBar): fixed iOS search bar icons issue

### DIFF
--- a/packages/base/src/SearchBar/SearchBar-ios.tsx
+++ b/packages/base/src/SearchBar/SearchBar-ios.tsx
@@ -19,13 +19,13 @@ export type { SearchBarIosProps };
 const defaultSearchIcon = (theme: Theme) => ({
   type: 'ionicon',
   size: 20,
-  name: 'ios-search',
+  name: 'search',
   color: theme?.colors?.platform?.ios?.grey,
 });
 
 const defaultClearIcon = (theme: Theme) => ({
   type: 'ionicon',
-  name: 'ios-close-circle',
+  name: 'close-circle',
   size: 20,
   color: theme?.colors?.platform?.ios?.grey,
 });
@@ -49,8 +49,8 @@ export class SearchBarIOS extends Component<SearchBarIosProps, SearchBarState> {
     onFocus: () => null,
     onBlur: () => null,
     onChangeText: () => null,
-    searchIcon: { name: 'ios-search' },
-    clearIcon: { name: 'ios-close-circle' },
+    searchIcon: { name: 'search' },
+    clearIcon: { name: 'close-circle' },
     showCancel: false,
   };
 


### PR DESCRIPTION
## Motivation

On Search Bar when passing "ios" to platform prop the icon shows question mark '?' symbol, which shows icon is not available and throws warning. Fixed this issue by modifying the SearchBar.ios.tsx by providing proper and available props for name property when displaying icons.

Fixes #3837

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Jest Unit Test
- [x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes

## Additional context

Before Fix

<img width="434" alt="Screenshot 2023-11-30 at 4 23 04 PM" src="https://github.com/react-native-elements/react-native-elements/assets/132579206/a69efbf9-fcae-4d84-81a4-56c532064419">


After Fix

<img width="425" alt="Screenshot 2023-11-30 at 4 22 38 PM" src="https://github.com/react-native-elements/react-native-elements/assets/132579206/76eaeff2-7549-4beb-8813-c90c5b0e7799">