### PR TITLE
fix(SocialIcon): Add missing apple social icon

### DIFF
--- a/packages/base/src/SocialIcon/SocialIcon.tsx
+++ b/packages/base/src/SocialIcon/SocialIcon.tsx
@@ -54,6 +54,7 @@ const colors = {
   youtube: '#bb0000',
   microsoft: '#46A4F2',
   reddit: '#ed452f',
+  apple: '#000000',
 };
 
 export type SocialMediaType =
@@ -86,7 +87,8 @@ export type SocialMediaType =
   | 'weibo'
   | 'vk'
   | 'microsoft'
-  | 'reddit';
+  | 'reddit'
+  | 'apple';
 
 export interface SocialIconProps extends InlinePressableProps {
   /** Type of button.


### PR DESCRIPTION
## Motivation

On SocialIcon component apple icon is missing, fixed issue by adding support for adding apple social icon.

Fixes #3834

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Jest Unit Test
- [x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes

## Additional context

Before adding apple icon

<img width="431" alt="Screenshot 2023-11-30 at 4 56 15 PM" src="https://github.com/react-native-elements/react-native-elements/assets/132579206/dd1b9646-2766-41e8-8d8e-3d893dbe1fda">

After adding apple icon

<img width="423" alt="Screenshot 2023-11-30 at 4 56 31 PM" src="https://github.com/react-native-elements/react-native-elements/assets/132579206/5450112e-c5b8-479c-a4c7-1bd3da1e69f7">

