### PR TITLE
fix: documentation navbar height bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
       "themed": "@rneui/themed",
       "website/docs": "Docs"
     }
+  },
+  "dependencies": {
+    "yarn": "^1.22.21"
   }
 }

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -433,7 +433,9 @@ nav.menu {
 .navbar__toggle svg {
   width: 21px;
 }
-
+.navbar-sidebar{
+  height: calc(100vh - 50px)
+}
 .navbar-sidebar__brand .navbar__brand {
   flex: 1 0;
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3153,7 +3153,7 @@ __metadata:
 
 "@rneui/base@file:../packages/base::locator=rne-website%40workspace%3A.":
   version: 4.0.0-rc.8
-  resolution: "@rneui/base@file:../packages/base#../packages/base::hash=902c90&locator=rne-website%40workspace%3A."
+  resolution: "@rneui/base@file:../packages/base#../packages/base::hash=03d59b&locator=rne-website%40workspace%3A."
   dependencies:
     "@types/react-native-vector-icons": ^6.4.10
     color: ^3.2.1
@@ -3164,7 +3164,7 @@ __metadata:
   peerDependencies:
     react-native-safe-area-context: ">= 3.0.0"
     react-native-vector-icons: ">7.0.0"
-  checksum: e0678ac67e70a5d67c40b13a4c5f123d0cd8373bd793cd0debbe0039448fe1535258d17aa011f2e34e8f2de50f7b55c981eb20a6f28da30729ec73cbcc4c6109
+  checksum: 7e30b0a7eaf65be2ed613c7e9018749912074980e3dd0c68d605fcff3356ac8e0a22ad5a383f102a31a07a635789afd13755c0030d413ce144aaafaa21ab45c3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17973,6 +17973,7 @@ __metadata:
     react-test-renderer: 18.0.0
     rimraf: ^3.0.2
     typescript: ^4.6.4
+    yarn: ^1.22.21
   languageName: unknown
   linkType: soft
 
@@ -21192,6 +21193,16 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
   checksum: 47da1b0d854fa16d45a3ded57b716b013b2179022352a5f7467409da5a04a1eef5b3b3d97a2dfc13e8bbe5f2ffc0afe3bc6a4a72f8254e60f5a4bd7947138643
+  languageName: node
+  linkType: hard
+
+"yarn@npm:^1.22.21":
+  version: 1.22.21
+  resolution: "yarn@npm:1.22.21"
+  bin:
+    yarn: bin/yarn.js
+    yarnpkg: bin/yarn.js
+  checksum: 791fab07ad55351049361686bcdd25c64a46e2afe2f2fc7587e666aa4f758d7eef80235b921aa09415557ac580ab23305c0181c1b43fed45f357a0c7a77322a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

fixes the documentation sidebar height bug for mobile screens

Fixes #3873

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


- [ ] navigate to '/docs'
- [ ] open mobile view using inspect (F12)
- [ ] open sideBar


## Additional context



https://github.com/react-native-elements/react-native-elements/assets/116783129/fae137f1-8dd9-4424-a512-02682ee77c91

