### PR TITLE
fix(base,example): Dialog.title not honoring theme in dark mode.

### DIFF
--- a/example/src/views/dialogs.tsx
+++ b/example/src/views/dialogs.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
-import { Button, Dialog, CheckBox, ListItem, Avatar } from '@rneui/themed';
-import { View, Text, StyleSheet } from 'react-native';
+import {
+  Button,
+  Dialog,
+  CheckBox,
+  ListItem,
+  Avatar,
+  Text,
+} from '@rneui/themed';
+import { View, StyleSheet } from 'react-native';
 import { Header } from '../components/header';
 
 type DialogComponentProps = {};
@@ -118,7 +125,7 @@ const Dialogs: React.FunctionComponent<DialogComponentProps> = () => {
           <CheckBox
             key={i}
             title={l}
-            containerStyle={{ backgroundColor: 'white', borderWidth: 0 }}
+            containerStyle={{ borderWidth: 0 }}
             checkedIcon="dot-circle-o"
             uncheckedIcon="circle-o"
             checked={checked === i + 1}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "lerna run build",
     "build:docs-api": "yarn workspace @rneui/doc-gen build",
-    "clean-build": "rm -rf packages/*/dist",
+    "clean-build": "rimraf packages/*/dist",
     "clean-install": "rimraf node_modules && yarn",
     "docs-build-api": "yarn workspace @rneui/doc-gen build",
     "docs-build": "yarn docs-build-api && cd website && yarn run build",

--- a/packages/base/src/Dialog/Dialog.Title.tsx
+++ b/packages/base/src/Dialog/Dialog.Title.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Text, StyleSheet, TextStyle, StyleProp, Platform } from 'react-native';
-import { RneFunctionComponent } from '../helpers';
-import { TextProps } from '../Text';
+import { StyleSheet, TextStyle, StyleProp, Platform } from 'react-native';
+import { defaultTheme, RneFunctionComponent } from '../helpers';
+import { TextProps, Text } from '../Text';
 
 export interface DialogTitleProps {
   /** Add Dialog title. */
@@ -19,11 +19,13 @@ export const DialogTitle: RneFunctionComponent<DialogTitleProps> = ({
   title,
   titleStyle,
   titleProps,
+  theme = defaultTheme,
 }) => {
   return (
     <Text
       style={StyleSheet.flatten([styles.title, titleStyle])}
       testID="Dialog__Title"
+      theme={theme}
       {...titleProps}
     >
       {title}

--- a/packages/themed/src/Dialog/__tests__/Dialog.test.tsx
+++ b/packages/themed/src/Dialog/__tests__/Dialog.test.tsx
@@ -20,10 +20,10 @@ describe('Dialog Component', () => {
     expect(wrapper.props.transparent).toBeFalsy();
   });
   it.each`
-   mode | expectedColor
-   ${'dark'} | ${darkColors.black}
-   ${'light'} | ${lightColors.black}
-  `('should apply $mode theme mode to Dialog', ({mode, expectedColor}) => {
+    mode       | expectedColor
+    ${'dark'}  | ${darkColors.black}
+    ${'light'} | ${lightColors.black}
+  `('should apply $mode theme mode to Dialog', ({ mode, expectedColor }) => {
     const theme: Partial<CreateThemeOptions> = {
       lightColors,
       darkColors,
@@ -37,6 +37,6 @@ describe('Dialog Component', () => {
       theme
     );
     const textComponent = getByText('Unit Test Title');
-    expect(textComponent.props.style.color).toEqual(expectedColor)
+    expect(textComponent.props.style.color).toEqual(expectedColor);
   });
 });

--- a/packages/themed/src/Dialog/__tests__/Dialog.test.tsx
+++ b/packages/themed/src/Dialog/__tests__/Dialog.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Dialog from '..';
-import { CreateThemeOptions } from '../..';
+import { CreateThemeOptions, darkColors, lightColors } from '../..';
 import { renderWithWrapper } from '../../../.ci/testHelper';
 
 describe('Dialog Component', () => {
@@ -18,5 +18,25 @@ describe('Dialog Component', () => {
       theme
     );
     expect(wrapper.props.transparent).toBeFalsy();
+  });
+  it.each`
+   mode | expectedColor
+   ${'dark'} | ${darkColors.black}
+   ${'light'} | ${lightColors.black}
+  `('should apply $mode theme mode to Dialog', ({mode, expectedColor}) => {
+    const theme: Partial<CreateThemeOptions> = {
+      lightColors,
+      darkColors,
+      mode,
+    };
+    const { getByText, toJSON } = renderWithWrapper(
+      <Dialog isVisible={true}>
+        <Dialog.Title title={'Unit Test Title'} />
+      </Dialog>,
+      'Dialog__Title',
+      theme
+    );
+    const textComponent = getByText('Unit Test Title');
+    expect(textComponent.props.style.color).toEqual(expectedColor)
   });
 });


### PR DESCRIPTION
Updates Dialog Title theme honoring and adds Testing for Dialog Title Updates clean command to use rimraf
Give some love to Dialog example component(fix checkbox example in dark mode)

Issue: https://github.com/react-native-elements/react-native-elements/issues/3876

## Motivation

Dialog.Title was not honoring the theming of the library

Fixes # [(issue)](https://github.com/react-native-elements/react-native-elements/issues/3876)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Was tested in my locale dev app using RNE libs, tested in example app, new JUnit tests introduced to verify and ensure it doesn't break again.

Basic setup of light mode and dark mode.  Flip to dark mode and it will not change the text to white.

- [X] Jest Unit Test
- [X] Checked with `example` app

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional context

Base Dialog.Title component was leveraging the react-native text component and there was no chance for the theme to be honored.  The Theme was also not being propogated properly.
