### PR TITLE
Website: increase the clickable area for the sponsors image

### DIFF
--- a/website/src/components/Sponsor.tsx
+++ b/website/src/components/Sponsor.tsx
@@ -19,6 +19,7 @@ export const OpenCollective: React.FC<{}> = () => (
             href="https://opencollective.com/react-native-elements#backers"
             target="_blank"
             rel="noopener noreferrer"
+            className="backers-image"
           >
             <img src="https://opencollective.com/react-native-elements/backers.svg?width=695" />
           </a>
@@ -30,7 +31,7 @@ export const OpenCollective: React.FC<{}> = () => (
           <h3>Sponsors</h3>
           <p className="p--desc ">
             Become a sponsor and get your logo on our README on GitHub with a
-            link to your site.
+            link to your site. 
             <a href="https://opencollective.com/react-native-elements#sponsor">
               Become a sponsor
             </a>
@@ -40,6 +41,7 @@ export const OpenCollective: React.FC<{}> = () => (
             href="https://opencollective.com/react-native-elements#sponsors"
             target="_blank"
             rel="noopener noreferrer"
+            className="backers-image"
           >
             <img src="https://opencollective.com/react-native-elements/sponsors.svg" />
           </a>

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -213,6 +213,10 @@ footer.nav-footer {
   margin-bottom: 30px;
 }
 
+.backers-images {
+  display: block;
+}
+
 .mainContainer .wrapper blockquote p:first-child {
   padding-top: 0;
 }


### PR DESCRIPTION
## Motivation

The clickable area for the sponsor's image didn't fit the image, making it difficult to click on it or on the "Become a Backer" button.

![image](https://github.com/react-native-elements/react-native-elements/assets/1556356/9073f016-b9af-453f-9b05-0b8fa1fb5820)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tried to run the website locally, but got this error:

```
[ERROR] Invalid docusaurus-theme-live-codeblock version 2.2.0.
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (2.3.0).
```

After updating the version to `2.3.0`, I got rid of the error, but the local URL still wasn't responding. I did not have the time to investigate further, so I only tested by changes directly in the developer tools.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
