### PR TITLE
fix(Slider): Animate transform, not width/height

### DIFF
--- a/packages/base/src/Slider/Slider.tsx
+++ b/packages/base/src/Slider/Slider.tsx
@@ -489,18 +489,22 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
     (thumbStart: Animated.Animated) => {
       const minimumTrackStyle: StyleProp<any> = {
         position: 'absolute',
+        transformOrigin: 'left top',
       };
       if (!allMeasured) {
         minimumTrackStyle.height = 0;
         minimumTrackStyle.width = 0;
       } else if (isVertical) {
-        minimumTrackStyle.height = Animated.add(
-          thumbStart,
-          thumbSize.height / 2
-        );
+        minimumTrackStyle.height = 1;
+        minimumTrackStyle.transform = [
+          { scaleY: Animated.add(thumbStart, thumbSize.height / 2) },
+        ];
         minimumTrackStyle.marginLeft = trackSize.width * TRACK_STYLE;
       } else {
-        minimumTrackStyle.width = Animated.add(thumbStart, thumbSize.width / 2);
+        minimumTrackStyle.width = 1;
+        minimumTrackStyle.transform = [
+          { scaleX: Animated.add(thumbStart, thumbSize.width / 2) },
+        ];
         minimumTrackStyle.marginTop = trackSize.height * TRACK_STYLE;
       }
       return minimumTrackStyle;

--- a/packages/base/src/Slider/Slider.tsx
+++ b/packages/base/src/Slider/Slider.tsx
@@ -490,6 +490,7 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
       const minimumTrackStyle: StyleProp<any> = {
         position: 'absolute',
         transformOrigin: 'left top',
+        borderRadius: 0,
       };
       if (!allMeasured) {
         minimumTrackStyle.height = 0;
@@ -499,24 +500,15 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
         minimumTrackStyle.transform = [
           { scaleY: Animated.add(thumbStart, thumbSize.height / 2) },
         ];
-        minimumTrackStyle.marginLeft = trackSize.width * TRACK_STYLE;
       } else {
         minimumTrackStyle.width = 1;
         minimumTrackStyle.transform = [
           { scaleX: Animated.add(thumbStart, thumbSize.width / 2) },
         ];
-        minimumTrackStyle.marginTop = trackSize.height * TRACK_STYLE;
       }
       return minimumTrackStyle;
     },
-    [
-      allMeasured,
-      isVertical,
-      thumbSize.height,
-      thumbSize.width,
-      trackSize.height,
-      trackSize.width,
-    ]
+    [allMeasured, isVertical, thumbSize.height, thumbSize.width]
   );
 
   const panResponder = useMemo(
@@ -574,20 +566,19 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
           mainStyles.track,
           isVertical ? mainStyles.trackVertical : mainStyles.trackHorizontal,
           appliedTrackStyle,
-          { backgroundColor: maximumTrackTintColor },
+          { backgroundColor: maximumTrackTintColor, overflow: 'hidden' },
         ])}
         onLayout={measureTrack}
-      />
-
-      <Animated.View
-        testID="RNE__Slider_Track_minimum"
-        style={StyleSheet.flatten([
-          mainStyles.track,
-          isVertical ? mainStyles.trackVertical : mainStyles.trackHorizontal,
-          appliedTrackStyle,
-          minimumTrackStyle,
-        ])}
-      />
+      >
+        <Animated.View
+          testID="RNE__Slider_Track_minimum"
+          style={StyleSheet.flatten([
+            isVertical ? mainStyles.trackVertical : mainStyles.trackHorizontal,
+            appliedTrackStyle,
+            minimumTrackStyle,
+          ])}
+        />
+      </View>
       <SliderThumb
         isVisible={allMeasured}
         onLayout={measureThumb}

--- a/packages/base/src/Slider/Slider.tsx
+++ b/packages/base/src/Slider/Slider.tsx
@@ -24,7 +24,6 @@ import { SliderThumb } from './components/SliderThumb';
 
 const TRACK_SIZE = 4;
 const THUMB_SIZE = 40;
-const TRACK_STYLE = Platform.select({ web: 0, default: -1 });
 const DEFAULT_ANIMATION_CONFIGS = {
   spring: {
     friction: 7,
@@ -52,7 +51,8 @@ const getBoundedValue = (
 const handlePanResponderRequestEnd = () => false;
 
 // Should we become active when the user moves a touch over the thumb?
-const handleMoveShouldSetPanResponder = () => !TRACK_STYLE;
+const SHOULD_MOVE_SET_PAN_RESPONDER = Platform.OS === 'web';
+const handleMoveShouldSetPanResponder = () => SHOULD_MOVE_SET_PAN_RESPONDER;
 
 type Sizable = {
   width: number;
@@ -63,7 +63,6 @@ type Sizable = {
 enum SizableVars {
   containerSize = 'containerSize',
   thumbSize = 'thumbSize',
-  trackSize = 'trackSize',
 }
 
 // enum to track event types
@@ -185,7 +184,6 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
     width: 0,
     height: 0,
   });
-  const [trackSize, setTrackSize] = useState<Sizable>({ width: 0, height: 0 });
   const [thumbSize, setThumbSize] = useState<Sizable>({ width: 0, height: 0 });
   const isVertical = orientation === 'vertical';
 
@@ -196,7 +194,6 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
       const varInfo = {
         containerSize: { size: containerSize, setSize: setContainerSize },
         thumbSize: { size: thumbSize, setSize: setThumbSize },
-        trackSize: { size: trackSize, setSize: setTrackSize },
       };
       const { size, setSize } = varInfo[name];
 
@@ -210,7 +207,7 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
       };
       setSize(newSize);
     },
-    [containerSize, isVertical, thumbSize, trackSize]
+    [containerSize, isVertical, thumbSize]
   );
 
   // use an effect to update allMeasured when sizes change
@@ -221,9 +218,7 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
           containerSize.height &&
           containerSize.width &&
           thumbSize.height &&
-          thumbSize.width &&
-          trackSize.height &&
-          trackSize.width
+          thumbSize.width
         )
       ),
     [
@@ -231,17 +226,11 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
       containerSize.width,
       thumbSize.height,
       thumbSize.width,
-      trackSize.height,
-      trackSize.width,
     ]
   );
 
   const measureContainer = useCallback(
     (event) => handleMeasure(SizableVars.containerSize, event),
-    [handleMeasure]
-  );
-  const measureTrack = useCallback(
-    (event) => handleMeasure(SizableVars.trackSize, event),
     [handleMeasure]
   );
   const measureThumb = useCallback(
@@ -568,7 +557,6 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
           appliedTrackStyle,
           { backgroundColor: maximumTrackTintColor, overflow: 'hidden' },
         ])}
-        onLayout={measureTrack}
       >
         <Animated.View
           testID="RNE__Slider_Track_minimum"


### PR DESCRIPTION
When resizing the mininum track of `<Slider/>`, animate transform properties (`scaleX`, `scaleY`) instead of `width` and `height`. This is needed because `width` and `height` cannot be animated with the native driver.

This fixes a bug that caused errors in iOS and Android simulators when `animateTransitions` is enabled.

## Motivation

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3928

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Jest Unit Test
- [x] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->