### PR TITLE
Remove defaultProps usages

### DIFF
--- a/packages/base/src/Dialog/Dialog.Button.tsx
+++ b/packages/base/src/Dialog/Dialog.Button.tsx
@@ -8,13 +8,17 @@ export interface DialogButtonProps extends ButtonProps {}
 /** This is used to add a button to the Dialog.
  * Receives all [Button](button#props) props. */
 export const DialogButton: RneFunctionComponent<DialogButtonProps> = ({
+  title = 'ACTION',
   titleStyle,
+  type = 'clear',
   ...rest
 }) => {
   return (
     <Button
       style={{ marginLeft: 5 }}
+      title={title}
       titleStyle={StyleSheet.flatten([styles.buttonTitle, titleStyle])}
+      type={type}
       containerStyle={{
         width: 'auto',
       }}
@@ -22,11 +26,6 @@ export const DialogButton: RneFunctionComponent<DialogButtonProps> = ({
       {...rest}
     />
   );
-};
-
-DialogButton.defaultProps = {
-  title: 'ACTION',
-  type: 'clear',
 };
 
 const styles = StyleSheet.create({

--- a/packages/base/src/Dialog/Dialog.Loading.tsx
+++ b/packages/base/src/Dialog/Dialog.Loading.tsx
@@ -20,7 +20,7 @@ export interface DialogLoadingProps {
 /** `DialogLoader` allows adding loader to the Dialog. Loader is simply ActivityIndicator. */
 export const DialogLoading: RneFunctionComponent<DialogLoadingProps> = ({
   loadingStyle,
-  loadingProps,
+  loadingProps = { size: 'large' },
   theme = defaultTheme,
 }) => {
   return (
@@ -34,10 +34,6 @@ export const DialogLoading: RneFunctionComponent<DialogLoadingProps> = ({
       />
     </View>
   );
-};
-
-DialogLoading.defaultProps = {
-  loadingProps: { size: 'large' },
 };
 
 const styles = StyleSheet.create({

--- a/packages/base/src/Slider/Slider.tsx
+++ b/packages/base/src/Slider/Slider.tsx
@@ -151,10 +151,10 @@ export interface SliderProps {
 /** Sliders allow users to select a value from a fixed set of values using drag utility.*/
 export const Slider: RneFunctionComponent<SliderProps> = ({
   allowTouchTrack = false,
-  animateTransitions,
-  animationConfig,
+  animateTransitions = false,
+  animationConfig = {},
   animationType = 'timing',
-  containerStyle,
+  containerStyle = styles,
   debugTouchArea = false,
   disabled,
   maximumTrackTintColor = '#b3b3b3',
@@ -170,7 +170,7 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
   thumbProps,
   thumbStyle,
   thumbTintColor = 'red',
-  thumbTouchSize = { height: THUMB_SIZE, width: THUMB_SIZE },
+  thumbTouchSize = { width: THUMB_SIZE, height: THUMB_SIZE },
   trackStyle,
   value: _propValue = 0,
   ...other
@@ -602,21 +602,6 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
       </View>
     </View>
   );
-};
-
-Slider.defaultProps = {
-  value: 0,
-  minimumValue: 0,
-  maximumValue: 1,
-  step: 0,
-  minimumTrackTintColor: '#3f3f3f',
-  maximumTrackTintColor: '#b3b3b3',
-  allowTouchTrack: false,
-  thumbTintColor: 'red',
-  thumbTouchSize: { width: THUMB_SIZE, height: THUMB_SIZE },
-  debugTouchArea: false,
-  animationType: 'timing',
-  orientation: 'horizontal',
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Motivation

defaultProps was flagged as deprecated in functional components in React 18.3, so using the latest React Native was throwing errors in the console to fix its usage.

Fixes
#3907 
#3918 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Jest Unit Test

Tried to run example app but it wouldn't load at all.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

