### PR TITLE
TextElement - defaultProps were removed in ver 3.x

### DIFF
--- a/src/text/Text.tsx
+++ b/src/text/Text.tsx
@@ -25,17 +25,17 @@ export type TextProps = TextProperties & {
 
 const TextElement: RneFunctionComponent<TextProps> = (props) => {
   const {
-    style,
+    style = {},
     theme,
     children = '',
-    h1,
-    h2,
-    h3,
-    h4,
-    h1Style,
-    h2Style,
-    h3Style,
-    h4Style,
+    h1 = false,
+    h2 = false,
+    h3 = false,
+    h4 = false,
+    h1Style = {},
+    h2Style = {},
+    h3Style = {},
+    h4Style = {},
     ...rest
   } = props;
 
@@ -62,18 +62,6 @@ const TextElement: RneFunctionComponent<TextProps> = (props) => {
       {children}
     </Text>
   );
-};
-
-TextElement.defaultProps = {
-  h1: false,
-  h2: false,
-  h3: false,
-  h4: false,
-  style: {},
-  h1Style: {},
-  h2Style: {},
-  h3Style: {},
-  h4Style: {},
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
**What kind of change does this PR introduce?**

For version 3.x remove defaultProps from TextElement

**Did you add tests for your changes?**
No - just made sure "yarn test" is still green

**If relevant, did you update the documentation?**
No

**Summary**

When using the CheckBox component got the following error:
`Warning: TextElement: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead`

<!-- Try to link to an open issue for more information. -->
https://github.com/react-native-elements/react-native-elements/pull/3942/files

**Does this PR introduce a breaking change?**
No

**Other information**
Version 3.4.3