### PR TITLE
fix: add math floor to fix arithmetic conversion

### DIFF
--- a/packages/base/src/Slider/Slider.tsx
+++ b/packages/base/src/Slider/Slider.tsx
@@ -561,7 +561,7 @@ export const Slider: RneFunctionComponent<SliderProps> = ({
       accessibilityValue={{
         min: minimumValue,
         max: maximumValue,
-        now: getCurrentValue(),
+        now: Math.floor(getCurrentValue()),
       }}
     >
       <View


### PR DESCRIPTION
## Motivation

Running the application on React Native 0.77 always gives an arithmetic conversion error. Using the math floor we ensure that the number is always an integer and thus it is possible to initialize the variable now and avoid arithmetic conversion errors.

Fixes # (issue)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How was this tested?

- [ ] Jest unit test
- [x] Checked with the `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-assessment of my own code
- [ ] I have commented my code, particularly in areas that are difficult to understand
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [ ] My changes do not generate new warnings
- [ ] I have added tests that prove that my fix is ​​effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] All dependent changes have been merged and published to downstream modules

## Additional context