### PR TITLE
Avoid type collapsing in iconType prop of Icon component

### DIFF
--- a/packages/base/src/Icon/Icon.tsx
+++ b/packages/base/src/Icon/Icon.tsx
@@ -36,7 +36,7 @@ export type IconType =
   | 'entypo'
   | 'antdesign'
   | 'font-awesome-5'
-  | string;
+  | (string & {});
 
 export interface IconObject {
   /** Test ID of icon. */


### PR DESCRIPTION
Types with string literals and `string` are collapsed to `string` by TypeScript. By changing the `string` to `string & {}` we can avoid this.

## Motivation

This allows to have autocomplete for the provided icon packs. Since they are not listed in the docs, it will be nice to view them in the autocomplete.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Changing the TypeScript type and viewing autocomplete options in `Icon` component at the `iconType` prop

- [x] Jest Unit Test
- [ ] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules