### PR TITLE
chore: update @rneui/base dependency to 5.0.0-beta.1

### DIFF
--- a/packages/themed/package.json
+++ b/packages/themed/package.json
@@ -64,10 +64,10 @@
     "logo": "https://opencollective.com/react-native-elements/logo.txt"
   },
   "peerDependencies": {
-    "@rneui/base": "4.0.0-rc.8"
+    "@rneui/base": "5.0.0-beta.1"
   },
   "devDependencies": {
-    "@rneui/base": "4.0.0-rc.8"
+    "@rneui/base": "5.0.0-beta.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
fix release 5.0.0-beta.1 build errors