### PR TITLE
 chore(release): bump version to 5.0.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rneui/base",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0",
   "description": "Cross Platform React Native UI Toolkit",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/themed/package.json
+++ b/packages/themed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rneui/themed",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0",
   "description": "Cross Platform React Native UI Toolkit",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -64,10 +64,10 @@
     "logo": "https://opencollective.com/react-native-elements/logo.txt"
   },
   "peerDependencies": {
-    "@rneui/base": "5.0.0-beta.1"
+    "@rneui/base": "5.0.0"
   },
   "devDependencies": {
-    "@rneui/base": "5.0.0-beta.1"
+    "@rneui/base": "5.0.0"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4964,7 +4964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rneui/base@npm:4.0.0-rc.8, @rneui/base@workspace:packages/base":
+"@rneui/base@npm:5.0.0, @rneui/base@workspace:packages/base":
   version: 0.0.0-use.local
   resolution: "@rneui/base@workspace:packages/base"
   dependencies:
@@ -5018,9 +5018,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rneui/themed@workspace:packages/themed"
   dependencies:
-    "@rneui/base": "npm:4.0.0-rc.8"
+    "@rneui/base": "npm:5.0.0"
   peerDependencies:
-    "@rneui/base": 4.0.0-rc.8
+    "@rneui/base": 5.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Updated "version": "5.0.0" in both base & themed
