### PR TITLE
fix(ci): Fix website deployment workflow

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -47,8 +47,13 @@ runs:
         restore-keys: |
           ${{ runner.os }}-rne-website-${{ hashFiles('website/yarn.lock') }}
 
+    - name: Activate Yarn for website
+      if: inputs.install_website == 'true'
+      run: corepack prepare yarn@3.2.4 --activate
+      shell: bash
+
     - name: Install website dependencies
       if: steps.website_cache.outputs.cache-hit != 'true' && inputs.install_website == 'true'
-      run: yarn install
+      run: yarn install --immutable
       working-directory: website
       shell: bash

--- a/website/.yarnrc.yml
+++ b/website/.yarnrc.yml
@@ -1,6 +1,7 @@
 nodeLinker: node-modules
 
-yarnPath: .yarn/releases/yarn-3.2.4.cjs
+# Commented out to use Corepack instead of committed binary
+# yarnPath: .yarn/releases/yarn-3.2.4.cjs
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3140,7 +3140,7 @@ __metadata:
 
 "@rneui/base@file:../packages/base::locator=rne-website%40workspace%3A.":
   version: 5.0.0
-  resolution: "@rneui/base@file:../packages/base#../packages/base::hash=431a73&locator=rne-website%40workspace%3A."
+  resolution: "@rneui/base@file:../packages/base#../packages/base::hash=bd5bf2&locator=rne-website%40workspace%3A."
   dependencies:
     color: ^3.2.1
     deepmerge: ^4.2.2
@@ -3150,7 +3150,7 @@ __metadata:
     "@testing-library/jest-native": ^5.4.3
     "@testing-library/react-native": ^13.2.0
     react-native-safe-area-context: ">= 3.0.0"
-  checksum: eddc0938f478e93031d03ca190701cc46d8417b547858e6ede653a6483ed6f815b91f5129a40c2518c2b3c95a59da21caa8d812c56636b5cd5da2740b53a26d8
+  checksum: 91ceb37db188f44ff93c1992af9a786734cf028f992809ab6b2f74921032b5809bd6f7b0a0b4278d5183f4b4b6361bb9fe0d60818584746db423a47cb6ddb320
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add Corepack activation step to prepare Yarn 3.2.4 before installing website dependencies. Update install command to use --immutable flag for reproducible builds.

fix(ci): Fix website deployment workflow

**Problem:**
- Website CI was failing with "lockfile would have been modified" error
- Yarn version mismatch between root (4.5.2) and website (3.2.4)
- Committed Yarn binary in website/.yarnrc.yml was overriding Corepack

**Solution:**
- Use Corepack to manage Yarn versions instead of committed binary
- Activate Yarn 3.2.4 explicitly for website installs
- Run `yarn install --immutable` in CI for reproducible builds
- Updated lockfile with current @rneui/base hash

**Changes:**
- .github/actions/install/action.yml: Added Yarn activation for website
- website/.yarnrc.yml: Removed yarnPath, use Corepack
- website/yarn.lock: Updated workspace dependency hash