### PR TITLE
fix(ci): yarn install type for website deployment

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -54,6 +54,6 @@ runs:
 
     - name: Install website dependencies
       if: steps.website_cache.outputs.cache-hit != 'true' && inputs.install_website == 'true'
-      run: yarn install --mode=update-lockfile
+      run: yarn install --no-immutable
       working-directory: website
       shell: bash


### PR DESCRIPTION
Update website install command to use --no-immutable flag
Replace --mode=update-lockfile with --no-immutable flag to allow lockfile updates during website dependency installation.