### PR TITLE
fix(button-group): support accessibilityLabel and accessibilityHint for custom buttons

### DIFF
--- a/example/src/views/buttons.tsx
+++ b/example/src/views/buttons.tsx
@@ -266,11 +266,28 @@ const Buttons: React.FunctionComponent<ButtonsComponentProps> = () => {
             }}
             containerStyle={{ marginBottom: 20 }}
           />
+          <ButtonGroup
+            buttons={accessibilityButtons}
+            selectedIndex={selectedIndex}
+            onPress={(value) => {
+              setSelectedIndex(value);
+            }}
+            containerStyle={{ marginBottom: 20 }}
+          />
         </View>
       </ScrollView>
     </>
   );
 };
+
+const accessibilityButtons = [
+  <Text accessibilityLabel="Podcast" accessibilityHint="Tap podcast">
+    Podcast
+  </Text>,
+  <Text accessibilityLabel="Host" accessibilityHint="Tap host">
+    Host
+  </Text>,
+];
 
 const CustomTitle = () => {
   return (

--- a/packages/base/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/base/src/ButtonGroup/ButtonGroup.tsx
@@ -24,6 +24,11 @@ type ButtonObject = {
   element: React.ElementType<any & { isSelected?: boolean }>;
 };
 
+type AccessibilityProps = {
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+};
+
 export interface ButtonGroupProps extends InlinePressableProps {
   /** Button for the component. */
   button?: object;
@@ -156,6 +161,14 @@ export const ButtonGroup: RneFunctionComponent<ButtonGroupProps> = ({
         const isDisabled =
           disabled === true ||
           (Array.isArray(disabled) && disabled.includes(i));
+        const isReactElement = React.isValidElement(button);
+
+        const elementProps = isReactElement
+          ? (button.props as AccessibilityProps)
+          : undefined;
+
+        const accessibilityLabel = elementProps?.accessibilityLabel;
+        const accessibilityHint = elementProps?.accessibilityHint;
         return (
           <View
             key={i}
@@ -184,6 +197,8 @@ export const ButtonGroup: RneFunctionComponent<ButtonGroupProps> = ({
               accessibilityState={{
                 disabled: isDisabled,
               }}
+              {...(accessibilityLabel && { accessibilityLabel })}
+              {...(accessibilityHint && { accessibilityHint })}
               activeOpacity={activeOpacity}
               setOpacityTo={setOpacityTo}
               onHideUnderlay={onHideUnderlay}


### PR DESCRIPTION
Fix: Accessibility support for ButtonGroup

Problem
Custom buttons passed to ButtonGroup do not propagate accessibilityLabel and accessibilityHint, so screen readers (TalkBack/VoiceOver) do not announce them.

Solution
	•	Extracted accessibility props from React elements
	•	Passed them to the underlying Pressable component

Testing
	•	Tested on Android emulator with TalkBack
	•	Verified correct announcement of label and hint

Example: 
  ```
const buttons = [
    <Text accessibilityLabel="Podcast" accessibilityHint="Tap podcast">
      Podcast
    </Text>,
  ];
```

### Checklist

- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] No new warnings introduced  
- [x] Tested in example app  
- [x] Accessibility verified using TalkBack  

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update required  

### Testing

- [x] Tested on Android emulator with TalkBack  
- [x] Verified correct announcement of label and hint  
- [ ] Unit tests added (not required for this change)