### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/website/docs/component_usage/Image.mdx
+++ b/website/docs/component_usage/Image.mdx
@@ -3,7 +3,7 @@ import React from 'react';
 import { FlatList, SafeAreaView, StyleSheet, ActivityIndicator } from 'react-native';
 import { Image } from '@rneui/themed';
 
-const BASE_URI = 'https://source.unsplash.com/random?sig=';
+const BASE_URI = 'https://picsum.photos/seed/rne-';
 
 const ImageAPI = () => {
 return (


### PR DESCRIPTION
`website/docs/component_usage/Image.mdx` references the deprecated `source.unsplash.com/*` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` (and related endpoints like `/featured`, `/collection/<id>`) was deprecated by Unsplash in mid-2024. These URLs now return HTTP 503 instead of an image, so browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600 | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Updates the `Image` component docs example's `BASE_URI` so the examples on the react-native-elements docs site actually render images instead of 503 icons when developers scroll the Image component page.

#### Replacement details

`picsum.photos/seed/rne-<sig>` preserves the deterministic per-sig behaviour the original URL provided (each sig maps to the same image on reload, which matters for the storybook-style examples on this docs page). Docs-only change — no runtime library behaviour is affected.

#### Background

I'm tracking the deprecated `source.unsplash.com/*` endpoints across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights this same broken-URL pattern in any landing page — useful for verifying the fix lands and for finding other places `source.unsplash.com/random` slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
