### PR TITLE
fix(Button): narrow ButtonProps children to ReactNode

### DIFF
--- a/packages/base/src/Button/Button.tsx
+++ b/packages/base/src/Button/Button.tsx
@@ -44,6 +44,10 @@ export interface ButtonProps extends PressableProps {
   /** Add button title. */
   title?: string | React.ReactElement<{}>;
 
+  /** Button content. Narrows the render-prop `children` inherited from
+   * `PressableProps`, which the Button component does not use. */
+  children?: React.ReactNode;
+
   /** Add additional styling for title component. */
   titleStyle?: StyleProp<TextStyle>;
 


### PR DESCRIPTION
## Motivation

`ButtonProps` extends `PressableProps`, which types `children` as `ReactNode | ((state: PressableStateCallbackType) => ReactNode)`. Since React 18, `@types/react` no longer accepts function children as a `ReactNode` in JSX, so any wrapper that spreads `ButtonProps` via `{...rest}` into `<Button />` fails to type-check:

```
Type '(state: PressableStateCallbackType) => ReactNode' is not assignable to type 'ReactNode'
```

```tsx
import { Button as RNEButton, type ButtonProps } from '@rneui/themed';

const Button = ({ ...rest }: ButtonProps) => {
  return <RNEButton {...rest} />; // TS2322 under @types/react 19
};
```

The `Button` component never uses the render-prop form of `children`. It defaults `children` to `title` and renders whatever it gets through `React.Children.toArray`, so the function variant is dead from the public API's point of view. Narrowing `children` to `ReactNode` on `ButtonProps` drops the variant the component doesn't support and lets these wrappers compile again.

This is a type-only change, no runtime behavior changes.

Fixes #4032

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Reproduced the error first, then confirmed the fix, with the versions already pinned in the repo (TypeScript 5.9, `@types/react` 19). A wrapper that does `<Button {...rest} />` reports TS2322 on `next` and type-checks clean with this change. `yarn typescript` passes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
