### PR TITLE
fix(ListItem): align Content and Title prop types with what they render

### DIFF
--- a/packages/base/src/ListItem/ListItem.Content.tsx
+++ b/packages/base/src/ListItem/ListItem.Content.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, ViewProps } from 'react-native';
 import { RneFunctionComponent } from '../helpers';
-import { TextProps } from '../Text';
 
-export interface ListItemContentProps extends TextProps {
+export interface ListItemContentProps extends ViewProps {
   right?: boolean;
 }
 

--- a/packages/base/src/ListItem/ListItem.Title.tsx
+++ b/packages/base/src/ListItem/ListItem.Title.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { StyleSheet, Platform, TextProps } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 import { RneFunctionComponent } from '../helpers';
-import { Text } from '../Text';
+import { Text, TextProps } from '../Text';
 
 const ANDROID_SECONDARY = 'rgba(0, 0, 0, 0.54)';
 


### PR DESCRIPTION
## Motivation

Fixes #3893.

Two `ListItem` subcomponents declare prop types that don't match the element they render, so following the docs for [extending the theme's `TextProps`](https://reactnativeelements.com/docs/customization/extending) produces TypeScript errors.

- `ListItem.Content` renders a `<View>` (and its JSDoc says "Receives all View props"), but `ListItemContentProps` extended `TextProps`. Text-only props were accepted by the type checker and then silently dropped at runtime by the `View`, while real `View` props were rejected.
- `ListItem.Title` renders the rneui `<Text>` component, but `ListItemTitleProps` extended react-native's `TextProps` instead of rneui's `../Text` `TextProps`. As a result the rneui-specific props (`h1`–`h4`, `h1Style`, ...) and any user-extended themed `TextProps` could not be passed to `ListItem.Title`, even though `ListItem.Content` accepted them.

This matches the report in the issue: the extra props ended up usable on `Content` (where they do nothing) but not on `Title` (where they belong).

## Changes

- `ListItem.Content.tsx`: `ListItemContentProps` now extends `ViewProps` (from `react-native`).
- `ListItem.Title.tsx`: `ListItemTitleProps` now extends `TextProps` from `../Text` (rneui) instead of `react-native`.

## Breaking change

Changing `ListItem.Content` from `TextProps` to `ViewProps` is a breaking change to that component's public prop types. Code that passed Text-only props to `ListItem.Content` will now get a type error. In practice those props were ignored at runtime already (the component renders a `View`), so this only surfaces an existing mismatch, but it is a type-level breaking change and I wanted to call it out explicitly in case you'd prefer to land it with the next major. The `Title` change is additive (it widens the accepted props), not breaking.

I kept the diff intentionally minimal. `ListItem.Subtitle` has the same react-native-vs-rneui `TextProps` mismatch as `Title`; I left it out to keep this PR focused, but I'm happy to include it here or in a follow-up if you'd like.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — applies to `ListItem.Content` only

## Test Plan

- `yarn install`
- `yarn typescript` (`tsc --noEmit`) passes on the full repo with the fix applied.
- Reverting just the two source changes makes `tsc` fail (e.g. `'h1' does not exist in type 'ListItemTitleProps'`), confirming the fix is what resolves the mismatch.
