### PR TITLE
fix(ButtonGroup): forward accessibility props

### DIFF
--- a/packages/base/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/base/src/ButtonGroup/ButtonGroup.tsx
@@ -8,6 +8,7 @@ import {
   StyleProp,
   TextStyle,
   Pressable,
+  AccessibilityProps,
 } from 'react-native';
 import {
   normalizeText,
@@ -20,6 +21,10 @@ import {
 import { Text } from '../Text';
 
 type ButtonComponent = React.ReactElement;
+type ButtonAccessibilityProps = Pick<
+  AccessibilityProps,
+  'accessibilityHint' | 'accessibilityLabel'
+>;
 type ButtonObject = {
   element: React.ElementType<any & { isSelected?: boolean }>;
 };
@@ -209,6 +214,7 @@ export const ButtonGroup: RneFunctionComponent<ButtonGroupProps> = ({
                 onPressOut,
                 onLongPress,
                 ...pressableProps,
+                ...getButtonAccessibilityProps(button),
               }}
             >
               <View
@@ -308,4 +314,18 @@ const hasElementKey = (
   return (
     typeof button === 'object' && Boolean((button as ButtonObject).element)
   );
+};
+
+const getButtonAccessibilityProps = (
+  button: string | ButtonComponent | ButtonObject
+): ButtonAccessibilityProps => {
+  if (!React.isValidElement<ButtonAccessibilityProps>(button)) {
+    return {};
+  }
+
+  const { accessibilityHint, accessibilityLabel } = button.props;
+  return {
+    ...(accessibilityHint !== undefined && { accessibilityHint }),
+    ...(accessibilityLabel !== undefined && { accessibilityLabel }),
+  };
 };

--- a/packages/base/src/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/packages/base/src/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -81,6 +81,34 @@ describe('ButtonGroup Component', () => {
     expect(onPress).toBeCalledWith(1);
   });
 
+  it('should forward accessibility metadata to each button', () => {
+    const accessibleButtons = [
+      <Text
+        key="first"
+        accessibilityLabel="First choice"
+        accessibilityHint="Selects first"
+      >
+        First
+      </Text>,
+      <Text
+        key="second"
+        accessibilityLabel="Second choice"
+        accessibilityHint="Selects second"
+      >
+        Second
+      </Text>,
+    ];
+    const { queryAllByTestId } = renderWithWrapper(
+      <ButtonGroup buttons={accessibleButtons} />
+    );
+
+    const renderedButtons = queryAllByTestId('RNE__ButtonGroupItem');
+    expect(renderedButtons[0].props.accessibilityLabel).toBe('First choice');
+    expect(renderedButtons[0].props.accessibilityHint).toBe('Selects first');
+    expect(renderedButtons[1].props.accessibilityLabel).toBe('Second choice');
+    expect(renderedButtons[1].props.accessibilityHint).toBe('Selects second');
+  });
+
   it('should render selectedIndex', () => {
     const { queryAllByTestId } = renderWithWrapper(
       <ButtonGroup


### PR DESCRIPTION
## Motivation

`ButtonGroup` renders each custom React element inside its own pressable wrapper. Screen readers inspect that wrapper, so `accessibilityLabel` and `accessibilityHint` set on the custom element are not announced. This change copies those two props onto the corresponding wrapper while preserving `pressableProps` as the fallback.

Fixes #3196

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Jest Unit Test
- [ ] Checked with `example` app

Verification:
- `yarn workspace @rneui/base test:ci` — 44 suites passed; 339 tests passed, 6 skipped; 71 snapshots passed
- `yarn workspace @rneui/base build`
- focused ESLint and Prettier checks on the changed files (the test file retains three pre-existing `no-shadow` warnings)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

`accessibilityRole` is intentionally outside this PR because #3822 already covers that separate behavior.