### PR TITLE
fix(Icon): own vector icon prop types

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -58,7 +58,6 @@
     "@react-native-vector-icons/octicons": "^20.3.0",
     "@types/color": "^3.0.3",
     "@types/hoist-non-react-statics": "^3.3.1",
-    "@types/react-native-vector-icons": "^6.4.10",
     "metro-react-native-babel-preset": "^0.70.2",
     "react-native-safe-area-context": "4.14.0"
   },

--- a/packages/base/src/Icon/Icon.tsx
+++ b/packages/base/src/Icon/Icon.tsx
@@ -9,11 +9,10 @@ import {
   Pressable,
   ColorValue,
   Text,
+  TextProps,
+  TouchableHighlightProps,
+  TouchableNativeFeedbackProps,
 } from 'react-native';
-import {
-  type IconButtonProps,
-  type IconProps as VectorIconProps,
-} from 'react-native-vector-icons/Icon';
 import Color from 'color';
 import getIconType from '../helpers/getIconType';
 import getIconStyle from '../helpers/getIconStyle';
@@ -23,6 +22,17 @@ import {
   InlinePressableProps,
   RneFunctionComponent,
 } from '../helpers';
+
+interface VectorIconProps extends TextProps {
+  /** Name of icon. */
+  name: string;
+
+  /** Size of icon. */
+  size?: number;
+
+  /** Color of icon. */
+  color?: ColorValue | number;
+}
 
 /**
  * @deprecated Use 'material-design' instead.
@@ -71,9 +81,37 @@ export interface IconObject {
 
 export type IconNode = boolean | React.ReactElement<{}> | Partial<IconProps>;
 
-export interface IconProps extends InlinePressableProps, IconButtonProps {
+export interface IconProps
+  extends InlinePressableProps,
+    Omit<
+      TextProps,
+      keyof TouchableHighlightProps | keyof TouchableNativeFeedbackProps
+    >,
+    TouchableHighlightProps,
+    TouchableNativeFeedbackProps {
   /** Test ID of icon. */
   testID?: string;
+
+  /** Name of icon. */
+  name: string;
+
+  /** Size of icon. */
+  size?: number;
+
+  /** Color of icon. */
+  color?: ColorValue | number;
+
+  /** Border radius of the icon container. */
+  borderRadius?: number;
+
+  /** Style applied to the icon. */
+  iconStyle?: TextStyle;
+
+  /** Style applied to the icon button. */
+  style?: ViewStyle | TextStyle;
+
+  /** Background color of the icon container. */
+  backgroundColor?: ColorValue | number;
 
   /** Type of icon set. [Supported sets here](#available-icon-sets). */
   type?: IconType;

--- a/website/docs/components/Icon.mdx
+++ b/website/docs/components/Icon.mdx
@@ -48,25 +48,32 @@ Includes all [Text](https://reactnative.dev/docs/text#props) props.
 
 <div class='table-responsive'>
 
-| Name             | Type                                 | Default                                           | Description                                                                  |
-| ---------------- | ------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `Component`      | React Component                      | `Press handlers present then Pressable else View` | Update React Native Component.                                               |
-| `brand`          | boolean                              | `false`                                           | Uses the brands font (FontAwesome5 only).                                    |
-| `containerStyle` | View Style                           |                                                   | Add styling to container holding icon.                                       |
-| `disabled`       | boolean                              | `false`                                           | Disables onPress events. Only works when `onPress` has a handler.            |
-| `disabledStyle`  | View Style                           |                                                   | Style for the button when disabled. Only works when `onPress` has a handler. |
-| `iconProps`      | IconProps                            |                                                   | Provide all props from react-native Icon component.                          |
-| `onLongPress`    | GestureResponderEventHandler         |                                                   | Called when a long-tap gesture is detected.                                  |
-| `onPress`        | GestureResponderEventHandler         |                                                   | Called when a single tap gesture is detected.                                |
-| `onPressIn`      | GestureResponderEventHandler         |                                                   | Called when a touch is engaged before `onPress`.                             |
-| `onPressOut`     | GestureResponderEventHandler         |                                                   | Called when a touch is released before `onPress`.                            |
-| `pressableProps` | PressableProps except click handlers | `None`                                            |                                                                              |
-| `raised`         | boolean                              | `false`                                           | Adds box shadow to button.                                                   |
-| `reverse`        | boolean                              | `false`                                           | Reverses color scheme.                                                       |
-| `reverseColor`   | string                               |                                                   | Specify reverse icon color.                                                  |
-| `solid`          | boolean                              | `false`                                           | Uses the solid font.                                                         |
-| `testID`         | string                               | `RNE__ICON__CONTAINER`                            | Test ID of icon.                                                             |
-| `type`           | IconType                             | `material`                                        | Type of icon set. [Supported sets here](#available-icon-sets).               |
+| Name              | Type                                 | Default                                           | Description                                                                  |
+| ----------------- | ------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `Component`       | React Component                      | `Press handlers present then Pressable else View` | Update React Native Component.                                               |
+| `backgroundColor` | `number` \| `ColorValue`             |                                                   | Background color of the icon container.                                      |
+| `borderRadius`    | number                               |                                                   | Border radius of the icon container.                                         |
+| `brand`           | boolean                              | `false`                                           | Uses the brands font (FontAwesome5 only).                                    |
+| `color`           | `number` \| `ColorValue`             |                                                   | Color of icon.                                                               |
+| `containerStyle`  | View Style                           |                                                   | Add styling to container holding icon.                                       |
+| `disabled`        | boolean                              | `false`                                           | Disables onPress events. Only works when `onPress` has a handler.            |
+| `disabledStyle`   | View Style                           |                                                   | Style for the button when disabled. Only works when `onPress` has a handler. |
+| `iconProps`       | VectorIconProps                      |                                                   | Provide all props from react-native Icon component.                          |
+| `iconStyle`       | TextStyle                            |                                                   | Style applied to the icon.                                                   |
+| `name`            | string                               |                                                   | Name of icon.                                                                |
+| `onLongPress`     | GestureResponderEventHandler         |                                                   | Called when a long-tap gesture is detected.                                  |
+| `onPress`         | GestureResponderEventHandler         |                                                   | Called when a single tap gesture is detected.                                |
+| `onPressIn`       | GestureResponderEventHandler         |                                                   | Called when a touch is engaged before `onPress`.                             |
+| `onPressOut`      | GestureResponderEventHandler         |                                                   | Called when a touch is released before `onPress`.                            |
+| `pressableProps`  | PressableProps except click handlers | `None`                                            |                                                                              |
+| `raised`          | boolean                              | `false`                                           | Adds box shadow to button.                                                   |
+| `reverse`         | boolean                              | `false`                                           | Reverses color scheme.                                                       |
+| `reverseColor`    | string                               |                                                   | Specify reverse icon color.                                                  |
+| `size`            | number                               | `24`                                              | Size of icon.                                                                |
+| `solid`           | boolean                              | `false`                                           | Uses the solid font.                                                         |
+| `style`           | `ViewStyle` \| `TextStyle`           |                                                   | Style applied to the icon button.                                            |
+| `testID`          | string                               | `RNE__ICON__CONTAINER`                            | Test ID of icon.                                                             |
+| `type`            | IconType                             | `material`                                        | Type of icon set. [Supported sets here](#available-icon-sets).               |
 
 </div>
 

--- a/website/docs/components/SpeedDial.Action.mdx
+++ b/website/docs/components/SpeedDial.Action.mdx
@@ -39,7 +39,7 @@ This, Receive all [Fab](fab#props) props.
 ## Props
 
 :::note
-Includes all [FAB](fab#props) props.
+Includes all [Button](button#props), [FAB](fab#props) props.
 :::
 
 <div class='table-responsive'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5298,7 +5298,6 @@ __metadata:
     "@react-native-vector-icons/octicons": "npm:^20.3.0"
     "@types/color": "npm:^3.0.3"
     "@types/hoist-non-react-statics": "npm:^3.3.1"
-    "@types/react-native-vector-icons": "npm:^6.4.10"
     color: "npm:^3.2.1"
     deepmerge: "npm:^4.2.2"
     hoist-non-react-statics: "npm:^3.3.2"
@@ -5846,16 +5845,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-native-vector-icons@npm:^6.4.10":
-  version: 6.4.18
-  resolution: "@types/react-native-vector-icons@npm:6.4.18"
-  dependencies:
-    "@types/react": "npm:*"
-    "@types/react-native": "npm:^0.70"
-  checksum: 10/1ef458cb5e7a37f41eb400e3153940b1b152e4df76a7c06c7a47c712dbfe46e14b9999f04dde1bd074f338f850e161c6c925174ddea33386b74f8112c940065b
-  languageName: node
-  linkType: hard
-
 "@types/react-native-web@npm:^0":
   version: 0.19.2
   resolution: "@types/react-native-web@npm:0.19.2"
@@ -5863,15 +5852,6 @@ __metadata:
     "@types/react": "npm:*"
     react-native: "npm:*"
   checksum: 10/bc27ccb2737283b78b41dacf605fc99b137091b49cd9b0b1bd2fab8c7950107314a04fc2351b0fcaaaeddea9ec101937fb6df24014f221a275a58666f60cfda0
-  languageName: node
-  linkType: hard
-
-"@types/react-native@npm:^0.70":
-  version: 0.70.19
-  resolution: "@types/react-native@npm:0.70.19"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10/43b280990f7a3c45cd707098d686ddbf353270cc463c9bb4306a5f675e3fe84010a32e344274b00b8a11629d73a8df1a1075af267d182a0f7094599616ae622c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

`@rneui/base` publishes `Icon.d.ts` with a type-only import from the legacy `react-native-vector-icons/Icon` package, but that package is only available as a development dependency. Consumers that use the modular icon packages therefore cannot resolve the declaration, and `IconProps` loses `name`, `size`, and `color`.

This change owns the small vector-icon type surface inside `@rneui/base`, preserves the existing Text/Touchable prop composition, and removes the obsolete `@types/react-native-vector-icons` development dependency (including its deprecated `@types/react-native` chain reported in #3915).

Fixes #4027

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Jest Unit Test
- [ ] Checked with `example` app

Verification:

- RED reproduction: hiding the dev-only legacy type package made `@rneui/base` fail with `TS2307` and removed `name`/`size`/`color` from `IconProps`
- `yarn install --immutable`
- `yarn workspace @rneui/base build`
- packed `@rneui/base` consumer fixture: `tsc --noEmit` with `skipLibCheck: false` and no legacy vector-icons package
- `yarn test` — 79 suites passed; 395 tests passed, 6 skipped; 76 snapshots passed
- `yarn typescript`
- `yarn lint`
- `yarn format`
- `yarn docs-build-api`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

The `Icon` and `SpeedDial.Action` documentation files are generated by `yarn docs-build-api`; the latter now reports both inherited `Button` and `FAB` props after the public Icon type is resolved locally.
