### PR TITLE
fix(SpeedDial): honor backdrop pressable props

### DIFF
--- a/packages/base/src/SpeedDial/SpeedDial.tsx
+++ b/packages/base/src/SpeedDial/SpeedDial.tsx
@@ -63,7 +63,12 @@ export const SpeedDial: RneFunctionComponent<SpeedDialProps> = ({
   theme = defaultTheme,
   placement,
   labelPressable,
-  backdropPressableProps: pressableProps,
+  backdropPressableProps: {
+    children: backdropChildren,
+    onPress: onBackdropPress,
+    style: backdropStyle,
+    ...backdropPressableProps
+  } = {},
   ...rest
 }) => {
   const animations = React.useRef<Animated.Value[]>(
@@ -87,26 +92,52 @@ export const SpeedDial: RneFunctionComponent<SpeedDialProps> = ({
     ).start();
   }, [isOpen, animations, children, transitionDuration]);
 
+  const backdropPressableStyle: PressableProps['style'] =
+    typeof backdropStyle === 'function'
+      ? (state) => [StyleSheet.absoluteFillObject, backdropStyle(state)]
+      : backdropStyle === undefined
+      ? [StyleSheet.absoluteFillObject]
+      : [StyleSheet.absoluteFillObject, backdropStyle];
+
+  const backdropOverlay = (
+    <Animated.View
+      style={[
+        StyleSheet.absoluteFillObject,
+        {
+          opacity: animations.current[0],
+          backgroundColor:
+            overlayColor ||
+            Color(theme?.colors?.black).alpha(0.6).rgb().toString(),
+        },
+      ]}
+    />
+  );
+
   return (
     <View style={[styles.container, style]} pointerEvents="box-none">
       {/* For overlay  */}
       <Pressable
-        {...pressableProps}
-        onPress={onClose}
-        style={[StyleSheet.absoluteFillObject]}
+        {...backdropPressableProps}
+        onPress={(event) => {
+          onClose();
+          onBackdropPress?.(event);
+        }}
+        style={backdropPressableStyle}
         pointerEvents={isOpen ? 'auto' : 'none'}
       >
-        <Animated.View
-          style={[
-            StyleSheet.absoluteFillObject,
-            {
-              opacity: animations.current[0],
-              backgroundColor:
-                overlayColor ||
-                Color(theme?.colors?.black).alpha(0.6).rgb().toString(),
-            },
-          ]}
-        />
+        {typeof backdropChildren === 'function' ? (
+          (state) => (
+            <>
+              {backdropOverlay}
+              {backdropChildren(state)}
+            </>
+          )
+        ) : (
+          <>
+            {backdropOverlay}
+            {backdropChildren}
+          </>
+        )}
       </Pressable>
 
       <SafeAreaView

--- a/packages/base/src/SpeedDial/__tests__/SpeedDial.test.tsx
+++ b/packages/base/src/SpeedDial/__tests__/SpeedDial.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { fireEvent } from '@testing-library/react-native';
 import { SpeedDial } from '..';
 import { renderWithWrapper } from '../../../.ci/testHelper';
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 
 describe('Speed Dial Component', () => {
   it('should match snapshot', () => {
@@ -24,5 +26,67 @@ describe('Speed Dial Component', () => {
       </SpeedDial>
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('applies custom backdrop style and children', () => {
+    const { getByTestId, getByText } = renderWithWrapper(
+      <SpeedDial
+        isOpen
+        icon={{ name: 'edit', color: '#fff' }}
+        backdropPressableProps={{
+          testID: 'custom-backdrop',
+          style: { backgroundColor: 'yellow' },
+          children: <Text>Backdrop content</Text>,
+        }}
+      />
+    );
+
+    expect(
+      StyleSheet.flatten(getByTestId('custom-backdrop').props.style)
+    ).toEqual(expect.objectContaining({ backgroundColor: 'yellow' }));
+    expect(getByText('Backdrop content')).toBeTruthy();
+  });
+
+  it('supports backdrop style and children render functions', () => {
+    const { getByTestId, getByText } = renderWithWrapper(
+      <SpeedDial
+        isOpen
+        icon={{ name: 'edit', color: '#fff' }}
+        backdropPressableProps={{
+          testID: 'custom-backdrop',
+          style: ({ pressed }) => ({ opacity: pressed ? 0.5 : 0.75 }),
+          children: ({ pressed }) => (
+            <Text>{pressed ? 'Pressed backdrop' : 'Idle backdrop'}</Text>
+          ),
+        }}
+      />
+    );
+
+    expect(
+      StyleSheet.flatten(getByTestId('custom-backdrop').props.style)
+    ).toEqual(expect.objectContaining({ opacity: 0.75 }));
+    expect(getByText('Idle backdrop')).toBeTruthy();
+  });
+
+  it('calls both onClose and the custom backdrop onPress handler', () => {
+    const onClose = jest.fn();
+    const onBackdropPress = jest.fn();
+    const pressEvent = { nativeEvent: { pageX: 10, pageY: 20 } };
+    const { getByTestId } = renderWithWrapper(
+      <SpeedDial
+        isOpen
+        icon={{ name: 'edit', color: '#fff' }}
+        onClose={onClose}
+        backdropPressableProps={{
+          testID: 'custom-backdrop',
+          onPress: onBackdropPress,
+        }}
+      />
+    );
+
+    fireEvent(getByTestId('custom-backdrop'), 'press', pressEvent);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onBackdropPress).toHaveBeenCalledWith(pressEvent);
   });
 });


### PR DESCRIPTION
## Motivation

SpeedDial accepts backdropPressableProps, but it spread those props before its own style, onPress, and JSX children. React therefore discarded the caller values for exactly the fields highlighted in #3937:

- custom backdrop style was replaced by the internal absolute-fill style
- custom children were replaced by the animated overlay
- custom onPress was replaced by onClose

This change treats the prop as a real PressableProps surface while preserving SpeedDial behavior:

- merges static and render-function styles after the required absolute-fill style
- renders static and render-function children above the animated overlay
- composes the custom onPress handler with onClose
- keeps pointerEvents owned by isOpen so a closed SpeedDial cannot intercept touches
- keeps the existing render tree unchanged when no custom backdrop props are supplied

Fixes #3937

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Jest Unit Test
- [ ] Checked with example app

TDD evidence:

- RED: custom backdrop style was absent and custom onPress had zero calls
- focused SpeedDial suite: 4/4 passed, existing snapshot unchanged
- full @rneui/base suite: 44 suites passed; 341 tests passed, 6 existing skips, 71 snapshots passed
- yarn typescript
- yarn lint
- yarn format
- yarn workspace @rneui/base build
- git diff --check

The suite still prints existing SafeAreaView and Tooltip deprecation warnings from untouched code paths; this PR adds no warning.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using yarn docs-build-api
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] No dependent changes are required

## Additional context

No dependency, lockfile, generated file, public type, or snapshot changes.